### PR TITLE
Default to production build, unless told otherwise

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "src/main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "NODE_ENV=development electron .",
     "pack": "build --dir",
     "dist": "build"
   },

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,3 +1,6 @@
+// First step: Always be production, unless told otherwise.
+if (process.env.NODE_ENV === undefined) process.env.NODE_ENV = "production";
+
 const {HOME_URL} = require('./defaults');
 window.onresize = doLayout;
 var isLoading = false;


### PR DESCRIPTION
It seems my last few changes adding development modes broke the release build, because I assumed `NODE_ENV` would always be `production` in a release build but apparently that's not the case.

See related discussion here: https://github.com/electron-userland/electron-builder/issues/1966

I don't really want to pull in [`electron-is-dev`](https://github.com/sindresorhus/electron-is-dev) just for this, so I'm doing the simple manual fix.