### PR TITLE
Vary home button behavior based on sign-in state

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -1,8 +1,7 @@
 // First step: Always be production, unless told otherwise.
 if (process.env.NODE_ENV === undefined) process.env.NODE_ENV = "production";
 
-const {session} = require('electron').remote;
-const {HOME_URL, MAKER_SETUP_URL} = require('./defaults');
+const {HOME_URL, MAKER_SETUP_URL, SIGN_IN_URL} = require('./defaults');
 
 window.onresize = doLayout;
 var isLoading = false;
@@ -21,7 +20,11 @@ onload = function() {
   };
 
   document.querySelector('#home').onclick = function() {
-    navigateTo(HOME_URL);
+    if (isSignedIn) {
+      navigateTo(HOME_URL);
+    } else {
+      navigateTo(SIGN_IN_URL)
+    }
   };
 
   document.querySelector('#reload').onclick = function() {

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,9 +1,12 @@
 // First step: Always be production, unless told otherwise.
 if (process.env.NODE_ENV === undefined) process.env.NODE_ENV = "production";
 
+const {session} = require('electron').remote;
 const {HOME_URL, MAKER_SETUP_URL} = require('./defaults');
+
 window.onresize = doLayout;
 var isLoading = false;
+var isSignedIn = false;
 
 onload = function() {
   var webview = document.querySelector('webview');
@@ -50,6 +53,54 @@ onload = function() {
 
   navigateTo(HOME_URL);
 };
+
+var _userNameCookieKey;
+function userNameCookieKey() {
+  if (_userNameCookieKey) {
+    return Promise.resolve(_userNameCookieKey);
+  }
+
+  return new Promise((resolve, reject) => {
+    var webview = document.querySelector('webview');
+    webview.executeJavaScript('window.userNameCookieKey', false, cookieKey => {
+      if (!cookieKey) {
+        return reject();
+      }
+      _userNameCookieKey = cookieKey;
+      resolve(cookieKey);
+    });
+  });
+}
+
+function readCookie(cookieKey) {
+  return new Promise((resolve, reject) => {
+    var webview = document.querySelector('webview');
+    const cookies = webview.getWebContents().session.cookies;
+    cookies.get(
+      {
+        name: cookieKey,
+        domain: '.code.org'
+      },
+      (_, foundCookies) => {
+        if (foundCookies.length > 0) {
+          resolve(foundCookies[0].value);
+        } else {
+          reject();
+        }
+      }
+    );
+  });
+}
+
+function checkSignInState() {
+  userNameCookieKey()
+    .then(key => readCookie(key))
+    .then(() => {
+      isSignedIn = true;
+    }).catch(() => {
+      isSignedIn = false;
+    });
+}
 
 function navigateTo(url) {
   resetExitedState();
@@ -111,6 +162,7 @@ function handleLoadStop(event) {
   // We don't remove the loading class immediately, instead we let the animation
   // finish, so that the spinner doesn't jerkily reset back to the 0 position.
   isLoading = false;
+  checkSignInState();
 }
 
 function handleLoadAbort(event) {


### PR DESCRIPTION
[From spec:](https://docs.google.com/document/d/1qYETgpZuYiubKVsRprgGzlj6kEb9W7Xc1Gt6as8v3sA/edit#bookmark=id.aqfov2eb59dc)

> Home button should take use to sign in page if they aren’t signed in and studio.code.org/home if they are signed in

While not a "perfect" check for whether we are signed in, we're [depending on the user short name cookie](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/initSigninState.js) to check sign-in state in our main application and this seems to be highly reliable (Brent just looked into this quite a bit).  I've done the same thing here, depending on getting the cookie name from the host page since it can change depending on whether we're in a dev, test or prod environment.

Right now we're only changing the Home button behavior based on this information - which is basically redundant because /home redirects to sign in if you're not signed in anyway. :man_shrugging: I guess this way we're more resilient if the redirect behavior changes?