### PR TITLE
Add custom menus

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -1,9 +1,26 @@
+const {ipcRenderer} = require('electron');
+
 // First step: Always be production, unless told otherwise.
 if (process.env.NODE_ENV === undefined) process.env.NODE_ENV = "production";
 
 const {HOME_URL} = require('./defaults');
 window.onresize = doLayout;
 var isLoading = false;
+
+// Handle requests from Electron menu items
+ipcRenderer.on('reload-requested', () => {
+  if (!isLoading) {
+    document.querySelector('webview').reload();
+  }
+});
+ipcRenderer.on('toggle-dev-tools-requested', () => {
+  const webview = document.querySelector('webview');
+  if (webview.isDevToolsOpened()) {
+    webview.closeDevTools();
+  } else {
+    webview.openDevTools();
+  }
+});
 
 onload = function() {
   var webview = document.querySelector('webview');

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 const {app, BrowserWindow} = require('electron');
 const path = require('path');
 const url = require('url');
+const setupMenus = require('./menus');
 
 let mainWindow = null;
 
@@ -23,6 +24,8 @@ function createMainWindow() {
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
+
+  setupMenus();
 }
 
 app.on('ready', createMainWindow);

--- a/src/menus.js
+++ b/src/menus.js
@@ -59,6 +59,24 @@ module.exports = function setupMenus() {
     }
   ];
 
+  // Special behavior for OSX to match usual menu patterns there:
+  if (process.platform === 'darwin') {
+    template.unshift({
+      label: app.getName(),
+      submenu: [
+        {role: 'about'},
+        {type: 'separator'},
+        {role: 'services', submenu: []},
+        {type: 'separator'},
+        {role: 'hide'},
+        {role: 'hideothers'},
+        {role: 'unhide'},
+        {type: 'separator'},
+        {role: 'quit'}
+      ]
+    })
+  }
+
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 };

--- a/src/menus.js
+++ b/src/menus.js
@@ -1,82 +1,111 @@
-const {Menu, shell} = require('electron');
+const {app, Menu, shell} = require('electron');
 const packageJson = require('../package.json');
 
-module.exports = function setupMenus() {
-  const template = [
-    {
-      label: 'View',
-      submenu: [
-        {
-          label: 'Reload',
-          accelerator: 'CmdOrCtrl+R',
-          click(_, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.webContents.send('reload-requested');
-            }
-          }
-        },
-        {
-          label: 'Toggle Developer Tools',
-          accelerator: (
-            process.platform === 'darwin' ?
-              'Alt+Command+I' :
-              'Ctrl+Shift+I'
-          ),
-          click(_, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.webContents.send('toggle-dev-tools-requested');
-            }
-          }
-        },
-        {
-          label: 'Toggle Electron Developer Tools',
-          click(_, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.webContents.toggleDevTools();
-            }
-          }
-        }
-      ]
-    },
-    {
-      role: 'help',
-      submenu: [
-        {
-          label: 'Maker Toolkit Browser',
-          enabled: false,
-        },
-        {
-          label: 'Code.org 2017',
-          enabled: false,
-        },
-        {
-          label: `Version ${packageJson.version}`,
-          click() {
-            shell.openExternal(`https://github.com/code-dot-org/browser/releases/tag/v${packageJson.version}`);
-          }
-        }
-      ]
+const RELOAD_WEBVIEW = {
+  label: 'Reload',
+  accelerator: 'CmdOrCtrl+R',
+  click(_, focusedWindow) {
+    if (focusedWindow) {
+      focusedWindow.webContents.send('reload-requested');
     }
-  ];
+  }
+};
 
-  // Special behavior for OSX to match usual menu patterns there:
+const TOGGLE_WEBVIEW_DEVTOOLS = {
+  label: 'Toggle Developer Tools',
+  accelerator: (
+    process.platform === 'darwin' ?
+      'Alt+Command+I' :
+      'Ctrl+Shift+I'
+  ),
+  click(_, focusedWindow) {
+    if (focusedWindow) {
+      focusedWindow.webContents.send('toggle-dev-tools-requested');
+    }
+  }
+};
+
+const TOGGLE_ELECTRON_DEVTOOLS = {
+  label: 'Toggle Electron Developer Tools',
+  click(_, focusedWindow) {
+    if (focusedWindow) {
+      focusedWindow.webContents.toggleDevTools();
+    }
+  }
+};
+
+const VERSION = {
+  label: `Version ${packageJson.version}`,
+  click() {
+    shell.openExternal(`https://github.com/code-dot-org/browser/releases/tag/v${packageJson.version}`);
+  }
+};
+
+module.exports = function setupMenus() {
+  // The initial menu item on Windows and Linux, often named 'File'
+  const fileMenu = {
+    label: 'File',
+    submenu: [
+      {role: 'quit'}
+    ]
+  };
+
+  // The initial menu item on OSX, always named for the application
+  const osxAppMenu = {
+    label: app.getName(),
+    submenu: [
+      {role: 'about'},
+      VERSION,
+      {type: 'separator'},
+      {role: 'services', submenu: []},
+      {type: 'separator'},
+      {role: 'hide'},
+      {role: 'hideothers'},
+      {role: 'unhide'},
+      {type: 'separator'},
+      {role: 'quit'}
+    ]
+  };
+
+  const viewMenu = {
+    label: 'View',
+    submenu: [
+      RELOAD_WEBVIEW,
+      TOGGLE_WEBVIEW_DEVTOOLS,
+      TOGGLE_ELECTRON_DEVTOOLS
+    ]
+  };
+
+  const helpMenu = {
+    label: 'Help',
+    submenu: [
+      {
+        label: 'Maker Toolkit Browser',
+        enabled: false,
+      },
+      VERSION,
+    ]
+  };
+
+  const osxHelpMenu = {
+    role: 'help'
+  };
+
+  // We define menus differently on OSX:
+  let menu;
   if (process.platform === 'darwin') {
-    template.unshift({
-      label: app.getName(),
-      submenu: [
-        {role: 'about'},
-        {type: 'separator'},
-        {role: 'services', submenu: []},
-        {type: 'separator'},
-        {role: 'hide'},
-        {role: 'hideothers'},
-        {role: 'unhide'},
-        {type: 'separator'},
-        {role: 'quit'}
-      ]
-    })
+    menu = Menu.buildFromTemplate([
+      osxAppMenu,
+      viewMenu,
+      osxHelpMenu
+    ]);
+  } else {
+    menu = Menu.buildFromTemplate([
+      fileMenu,
+      viewMenu,
+      helpMenu
+    ]);
   }
 
-  const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 };

--- a/src/menus.js
+++ b/src/menus.js
@@ -1,0 +1,64 @@
+const {Menu, shell} = require('electron');
+const packageJson = require('../package.json');
+
+module.exports = function setupMenus() {
+  const template = [
+    {
+      label: 'View',
+      submenu: [
+        {
+          label: 'Reload',
+          accelerator: 'CmdOrCtrl+R',
+          click(_, focusedWindow) {
+            if (focusedWindow) {
+              focusedWindow.webContents.send('reload-requested');
+            }
+          }
+        },
+        {
+          label: 'Toggle Developer Tools',
+          accelerator: (
+            process.platform === 'darwin' ?
+              'Alt+Command+I' :
+              'Ctrl+Shift+I'
+          ),
+          click(_, focusedWindow) {
+            if (focusedWindow) {
+              focusedWindow.webContents.send('toggle-dev-tools-requested');
+            }
+          }
+        },
+        {
+          label: 'Toggle Electron Developer Tools',
+          click(_, focusedWindow) {
+            if (focusedWindow) {
+              focusedWindow.webContents.toggleDevTools();
+            }
+          }
+        }
+      ]
+    },
+    {
+      role: 'help',
+      submenu: [
+        {
+          label: 'Maker Toolkit Browser',
+          enabled: false,
+        },
+        {
+          label: 'Code.org 2017',
+          enabled: false,
+        },
+        {
+          label: `Version ${packageJson.version}`,
+          click() {
+            shell.openExternal(`https://github.com/code-dot-org/browser/releases/tag/v${packageJson.version}`);
+          }
+        }
+      ]
+    }
+  ];
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+};


### PR DESCRIPTION
![out](https://user-images.githubusercontent.com/1615761/32200641-f45a323e-bd8f-11e7-9d9e-4e9f0cd73879.gif)

Adds simple custom menus to the browser (where previously we had none at all).  I'm mostly doing this for our own uses, providing these two features:

* We can quickly check which version of the browser we're looking at in the help menu.
* We can toggle developer tools (for either the electron layer or the webview layer) at will in our release builds.

The latter I especially need to track down a Maker connection bug that won't repro with development builds but does repro with release builds coming out of Travis.

References: [This documentation](https://electron.atom.io/docs/api/menu/) and [this tutorial](https://www.christianengvall.se/electron-menu/).