### PR TITLE
Update how we check sign-in state

### DIFF
--- a/src/User.js
+++ b/src/User.js
@@ -1,0 +1,71 @@
+/**
+ * Model for Code.org user information for use from the Maker Browser context.
+ * @class User
+ */
+class User {
+  constructor(name) {
+    Object.defineProperty(this, 'name', {
+      value: name,
+      enumerable: true
+    });
+  }
+
+  /**
+   * Check for the currently signed-in user, by querying the loaded Code.org
+   * page in the webview.
+   * Assumes access to the Electron document (should be called on Render thread)
+   * @return {Promise.<User>} Resolves to an initialized User object if the
+   *   current user is signed in on a Code.org page, rejects otherwise.
+   */
+  static getCurrentUser() {
+    const webview = document.querySelector('webview');
+    return readRackEnv(webview)
+      .then(rackEnv => readCookie(webview, shortNameCookie(rackEnv)))
+      .then(shortName => new User(shortName))
+      .catch(err => Promise.reject(err))
+  }
+}
+
+/**
+ * @param {webview} webview
+ * @returns {Promise.<string>} resolved to rack env for page loaded in webview
+ */
+function readRackEnv(webview) {
+  return new Promise((resolve, reject) => {
+    webview.executeJavaScript('window.dashboard.rack_env', false, (rackEnv) => {
+      rackEnv ? resolve(rackEnv) : reject();
+    });
+  });
+}
+
+function shortNameCookie(rackEnv) {
+  return environmentifyCookie(rackEnv, '_shortName');
+}
+
+function environmentifyCookie(rackEnv, cookieName) {
+  if (rackEnv === 'production') {
+    return cookieName;
+  }
+  return `${cookieName}_${rackEnv}`;
+}
+
+function readCookie(webview, cookieName) {
+  return new Promise((resolve, reject) => {
+    const cookies = webview.getWebContents().session.cookies;
+    cookies.get(
+      {
+        name: cookieName,
+        domain: '.code.org'
+      },
+      (_, foundCookies) => {
+        if (foundCookies.length > 0) {
+          resolve(foundCookies[0].value);
+        } else {
+          reject();
+        }
+      }
+    );
+  });
+}
+
+module.exports = User;

--- a/src/User.js
+++ b/src/User.js
@@ -3,6 +3,9 @@
  * @class User
  */
 class User {
+  /**
+   * @param {string} name - User's display name.  Read-only after it's set here.
+   */
   constructor(name) {
     Object.defineProperty(this, 'name', {
       value: name,
@@ -27,7 +30,7 @@ class User {
 }
 
 /**
- * @param {webview} webview
+ * @param {WebviewTag} webview
  * @returns {Promise.<string>} resolved to rack env for page loaded in webview
  */
 function readRackEnv(webview) {
@@ -38,10 +41,19 @@ function readRackEnv(webview) {
   });
 }
 
+/**
+ * @param {string} rackEnv
+ * @return {string} cookie key for current user's short display name
+ */
 function shortNameCookie(rackEnv) {
   return environmentifyCookie(rackEnv, '_shortName');
 }
 
+/**
+ * @param {string} rackEnv
+ * @param {string} cookieName in production environment
+ * @returns {string} cookie key adjusted for given rack environment
+ */
 function environmentifyCookie(rackEnv, cookieName) {
   if (rackEnv === 'production') {
     return cookieName;
@@ -49,6 +61,12 @@ function environmentifyCookie(rackEnv, cookieName) {
   return `${cookieName}_${rackEnv}`;
 }
 
+/**
+ * @param {WebviewTag} webview
+ * @param {string} cookieName
+ * @returns {Promise.<string>} Resolves to cookie value if cookie is found,
+ *   otherwise rejects.
+ */
 function readCookie(webview, cookieName) {
   return new Promise((resolve, reject) => {
     const cookies = webview.getWebContents().session.cookies;

--- a/src/browser.js
+++ b/src/browser.js
@@ -74,6 +74,13 @@ onload = function() {
   navigateTo(HOME_URL);
 };
 
+function environmentSpecificCookieName(rackEnv, cookieName) {
+  if (rackEnv === 'production') {
+    return cookieName;
+  }
+  return `${cookieName}_${rackEnv}`;
+}
+
 var _userNameCookieKey;
 function userNameCookieKey() {
   if (_userNameCookieKey) {
@@ -82,12 +89,12 @@ function userNameCookieKey() {
 
   return new Promise((resolve, reject) => {
     var webview = document.querySelector('webview');
-    webview.executeJavaScript('window.userNameCookieKey', false, cookieKey => {
-      if (!cookieKey) {
+    webview.executeJavaScript('window.dashboard.rack_env', false, rackEnv => {
+      if (!rackEnv) {
         return reject();
       }
-      _userNameCookieKey = cookieKey;
-      resolve(cookieKey);
+      _userNameCookieKey = environmentSpecificCookieName(rackEnv, '_shortName');
+      resolve(_userNameCookieKey);
     });
   });
 }


### PR DESCRIPTION
The `userNameCookieKey` was removed from our main project by Brent today in [this pull request](https://github.com/code-dot-org/code-dot-org/pull/18814).  Instead, the client has access to the current `rack_env` and has to adjust its own cookie keys accordingly.

Once I had that working, I encapsulated much of this logic into a helper class.  It's probably time to start organizing this code! :grin: