### PR TITLE
Google OAuth support

### DIFF
--- a/src/originWhitelist.js
+++ b/src/originWhitelist.js
@@ -14,7 +14,7 @@ const {URL} = require('url');
  * if the origin falls within our general Code.org origin whitelist.
  * @type {Array.<RegExp>}
  */
-const BLACKLIST = [
+const INTERNAL_BLACKLIST = [
   /curriculum\.code\.org$/i,
   /docs\.code\.org$/i,
   /forum\.code\.org$/i,
@@ -30,12 +30,26 @@ const BLACKLIST = [
 const CODE_ORG_URL = /^https?:\/\/(?:[\w\d-]+\.)?(?:cdn-)?code\.org(?::\d+)?$/i;
 
 /**
+ * Limited set of non-Code.org origins we will load within Maker Toolkit Browser,
+ * mostly for things like OAuth or other integrations with external services.
+ * @type {Array}
+ */
+const EXTERNAL_WHITELIST = [
+  /accounts\.google\.com$/i,
+];
+
+/**
  * @param {string} origin
  * @returns {boolean} whether the origin is included in the whitelist
  */
 function isOriginWhitelisted(origin) {
-  return CODE_ORG_URL.test(origin) &&
-    !BLACKLIST.some(site => site.test(origin));
+  return (
+    (
+      CODE_ORG_URL.test(origin) &&
+      !INTERNAL_BLACKLIST.some(site => site.test(origin))
+    ) ||
+    EXTERNAL_WHITELIST.some(site => site.test(origin))
+  );
 }
 
 /**

--- a/src/preload.js
+++ b/src/preload.js
@@ -10,11 +10,10 @@
 
 const SerialPort = require('serialport');
 const packageJson = require('../package.json');
-const {isOriginWhitelisted} = require('./originWhitelist');
+const {mayInjectNativeApi} = require('./originWhitelist');
 
 function init() {
-  // Don't inject anything if the current page isn't in our whitelist
-  if (!isOriginWhitelisted(document.location.origin)) {
+  if (!mayInjectNativeApi(document.location.origin)) {
     return;
   }
 

--- a/src/wrapNavigation.js
+++ b/src/wrapNavigation.js
@@ -4,7 +4,7 @@
  * Process: Main
  */
 const {app, shell, BrowserWindow} = require('electron');
-const {isUrlWhitelisted} = require('./originWhitelist');
+const {openUrlInDefaultBrowser} = require('./originWhitelist');
 const {NAVIGATION_REQUESTED} = require('./channelNames');
 
 /**
@@ -31,7 +31,7 @@ function wrapNavigation() {
     // walled garden of whitelisted origins.
     // @see https://electron.atom.io/docs/api/web-contents/#event-will-navigate
     webContents.on('will-navigate', (event, url) => {
-      if (!isUrlWhitelisted(url)) {
+      if (openUrlInDefaultBrowser(url)) {
         event.preventDefault();
         shell.openExternal(url);
       }
@@ -51,15 +51,15 @@ function wrapNavigation() {
       // @see https://github.com/electron/electron/issues/1963
       event.preventDefault();
 
-      if (isUrlWhitelisted(url)) {
+      if (openUrlInDefaultBrowser(url)) {
+        shell.openExternal(url);
+      } else {
         const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.send(NAVIGATION_REQUESTED, url);
         } else {
           console.warn('Unable to navigate, there is no focused window.');
         }
-      } else {
-        shell.openExternal(url);
       }
     });
   });

--- a/test/originWhitelistTest.js
+++ b/test/originWhitelistTest.js
@@ -1,10 +1,10 @@
 const { expect } = require('chai');
 const {
-  isOriginWhitelisted,
-  isUrlWhitelisted,
+  openUrlInDefaultBrowser,
+  mayInjectNativeApi,
 } = require('../src/originWhitelist');
 
-const WHITELISTED_ORIGINS = [
+const WHITELISTED_INTERNAL_ORIGINS = [
   // Production
   'https://code.org',
   'https://studio.code.org',
@@ -17,6 +17,9 @@ const WHITELISTED_ORIGINS = [
   // Local development
   'http://localhost.code.org:3000',
   'http://localhost-studio.code.org:3000',
+];
+
+const WHITELISTED_EXTERNAL_ORIGINS = [
   // Google OAuth
   'https://accounts.google.com',
 ];
@@ -29,30 +32,44 @@ const BLACKLISTED_ORIGINS = [
   'https://wiki.code.org',
 ];
 
-describe('isOriginWhitelisted', () => {
-  WHITELISTED_ORIGINS.forEach((origin) => {
-    it(`allows ${origin}`, () => {
-      expect(isOriginWhitelisted(origin)).to.be.true;
+describe('openUrlInDefaultBrowser', () => {
+  // These should load in the system default browser
+  [
+    ...BLACKLISTED_ORIGINS,
+  ].forEach((origin) => {
+    it(`true for ${origin}`, () => {
+      expect(openUrlInDefaultBrowser(`${origin}/any/test/path`)).to.be.true;
     });
   });
 
-  BLACKLISTED_ORIGINS.forEach((origin) => {
-    it(`blocks ${origin}`, () => {
-      expect(isOriginWhitelisted(origin)).to.be.false;
+  // These should load within Maker Toolkit
+  [
+    ...WHITELISTED_INTERNAL_ORIGINS,
+    ...WHITELISTED_EXTERNAL_ORIGINS,
+  ].forEach((origin) => {
+    it(`false for ${origin}`, () => {
+      expect(openUrlInDefaultBrowser(`${origin}/any/test/path`)).to.be.false;
     });
   });
 });
 
-describe('isUrlWhitelisted', () => {
-  WHITELISTED_ORIGINS.forEach((origin) => {
+describe('mayInjectNativeApi', () => {
+  // These should get the native APIs injected into the page
+  [
+    ...WHITELISTED_INTERNAL_ORIGINS,
+  ].forEach((origin) => {
     it(`allows ${origin}`, () => {
-      expect(isUrlWhitelisted(`${origin}/any/test/path`)).to.be.true;
+      expect(mayInjectNativeApi(origin)).to.be.true;
     });
   });
 
-  BLACKLISTED_ORIGINS.forEach((origin) => {
+  // These should never get native APIs injected into the page
+  [
+    ...WHITELISTED_EXTERNAL_ORIGINS,
+    ...BLACKLISTED_ORIGINS,
+  ].forEach((origin) => {
     it(`blocks ${origin}`, () => {
-      expect(isUrlWhitelisted(`${origin}/any/test/path`)).to.be.false;
+      expect(mayInjectNativeApi(origin)).to.be.false;
     });
   });
 });

--- a/test/originWhitelistTest.js
+++ b/test/originWhitelistTest.js
@@ -17,6 +17,8 @@ const WHITELISTED_ORIGINS = [
   // Local development
   'http://localhost.code.org:3000',
   'http://localhost-studio.code.org:3000',
+  // Google OAuth
+  'https://accounts.google.com',
 ];
 
 const BLACKLISTED_ORIGINS = [


### PR DESCRIPTION
Whitelists `accounts.google.com` to load within the Maker Toolkit Browser, which lets students sign in to Code.org with Google OAuth entirely within the app.

That change was small - the rest of the diff is rearranging the whitelist logic to have slightly different whitelists for what loads within the app, and which pages get the native APIs we need for Maker functionality.  In short: Only pages at Code.org-owned origins get the native APIs, while the whitelist of pages to load in the app is slightly broader than that.