### PR TITLE
Facebook OAuth support

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     }
   },
   "dependencies": {
+    "lodash": "^4.17.4",
     "serialport": "6.0.4"
   },
   "devDependencies": {

--- a/src/originWhitelist.js
+++ b/src/originWhitelist.js
@@ -30,14 +30,18 @@ const INTERNAL_BLACKLIST = [
 ];
 
 /**
- * Limited set of non-Code.org origins we will load within Maker Toolkit Browser,
+ * Limited set of non-Code.org pages we will load within Maker Toolkit Browser,
  * mostly for things like OAuth or other integrations with external services.
  * We won't inject native APIs to these sites even though they load within the
  * app.
  * @type {Array.<RegExp>}
  */
 const EXTERNAL_WHITELIST = [
-  /accounts\.google\.com$/i,
+  // Google OAuth
+  /accounts\.google\.com(?:$|\/)/i,
+  // Facebook OAuth
+  /www\.facebook\.com\/v2.6\/dialog\/oauth/i,
+  /www\.facebook\.com\/logout/i,
 ];
 
 /**
@@ -47,7 +51,7 @@ const EXTERNAL_WHITELIST = [
  */
 function openUrlInDefaultBrowser(url) {
   const origin = new URL(url).origin;
-  return !(originIsOnInternalWhitelist(origin) || originIsOnExternalWhitelist(origin));
+  return !(originIsOnInternalWhitelist(origin) || urlIsOnExternalWhitelist(url));
 }
 
 /**
@@ -64,8 +68,8 @@ function originIsOnInternalWhitelist(origin) {
     !INTERNAL_BLACKLIST.some(site => site.test(origin));
 }
 
-function originIsOnExternalWhitelist(origin) {
-  return EXTERNAL_WHITELIST.some(site => site.test(origin));
+function urlIsOnExternalWhitelist(url) {
+  return EXTERNAL_WHITELIST.some(site => site.test(url));
 }
 
 module.exports = {

--- a/src/originWhitelist.js
+++ b/src/originWhitelist.js
@@ -14,7 +14,7 @@ const {URL} = require('url');
  * if the origin falls within our general Code.org origin whitelist.
  * @type {Array.<RegExp>}
  */
-const BLACKLIST = [
+const INTERNAL_BLACKLIST = [
   /curriculum\.code\.org$/i,
   /docs\.code\.org$/i,
   /forum\.code\.org$/i,
@@ -30,12 +30,26 @@ const BLACKLIST = [
 const CODE_ORG_URL = /^https?:\/\/(?:[\w\d-]+\.)?(?:cdn-)?code\.org(?::\d+)?$/i;
 
 /**
+ * Limited set of non-Code.org origins we will load within Maker Toolkit Browser,
+ * mostly for things like OAuth or other integrations with external services.
+ * @type {Array}
+ */
+const EXTERNAL_WHITELIST = [
+  /accounts\.google\.com$/i,
+];
+
+/**
  * @param {string} origin
  * @returns {boolean} whether the origin is included in the whitelist
  */
 function isOriginWhitelisted(origin) {
-  return CODE_ORG_URL.test(origin) &&
-    !BLACKLIST.some(site => site.test(origin));
+  return (
+    (
+      CODE_ORG_URL.test(origin) &&
+      !INTERNAL_BLACKLIST.some(site => site.test(origin))
+    ) ||
+    EXTERNAL_WHITELIST.some(site => site.test(origin))
+  );
 }
 
 /**

--- a/src/preload.js
+++ b/src/preload.js
@@ -10,11 +10,10 @@
 
 const SerialPort = require('serialport');
 const packageJson = require('../package.json');
-const {isOriginWhitelisted} = require('./originWhitelist');
+const {mayInjectNativeApi} = require('./originWhitelist');
 
 function init() {
-  // Don't inject anything if the current page isn't in our whitelist
-  if (!isOriginWhitelisted(document.location.origin)) {
+  if (!mayInjectNativeApi(document.location.origin)) {
     return;
   }
 

--- a/src/wrapNavigation.js
+++ b/src/wrapNavigation.js
@@ -4,7 +4,7 @@
  * Process: Main
  */
 const {app, shell, BrowserWindow} = require('electron');
-const {isUrlWhitelisted} = require('./originWhitelist');
+const {openUrlInDefaultBrowser} = require('./originWhitelist');
 const {NAVIGATION_REQUESTED} = require('./channelNames');
 
 /**
@@ -31,7 +31,7 @@ function wrapNavigation() {
     // walled garden of whitelisted origins.
     // @see https://electron.atom.io/docs/api/web-contents/#event-will-navigate
     webContents.on('will-navigate', (event, url) => {
-      if (!isUrlWhitelisted(url)) {
+      if (openUrlInDefaultBrowser(url)) {
         event.preventDefault();
         shell.openExternal(url);
       }
@@ -51,15 +51,15 @@ function wrapNavigation() {
       // @see https://github.com/electron/electron/issues/1963
       event.preventDefault();
 
-      if (isUrlWhitelisted(url)) {
+      if (openUrlInDefaultBrowser(url)) {
+        shell.openExternal(url);
+      } else {
         const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.send(NAVIGATION_REQUESTED, url);
         } else {
           console.warn('Unable to navigate, there is no focused window.');
         }
-      } else {
-        shell.openExternal(url);
       }
     });
   });

--- a/test/originWhitelistTest.js
+++ b/test/originWhitelistTest.js
@@ -1,10 +1,11 @@
 const { expect } = require('chai');
+const {URL} = require('url');
 const {
   openUrlInDefaultBrowser,
   mayInjectNativeApi,
 } = require('../src/originWhitelist');
 
-const WHITELISTED_INTERNAL_ORIGINS = [
+const WHITELISTED_INTERNAL_PAGES = [
   // Production
   'https://code.org',
   'https://studio.code.org',
@@ -19,36 +20,48 @@ const WHITELISTED_INTERNAL_ORIGINS = [
   'http://localhost-studio.code.org:3000',
 ];
 
-const WHITELISTED_EXTERNAL_ORIGINS = [
+const WHITELISTED_EXTERNAL_PAGES = [
   // Google OAuth
   'https://accounts.google.com',
+  'https://accounts.google.com/signin/oauth',
+  'https://accounts.google.com/logout',
+  // Facebook OAuth
+  'https://www.facebook.com/v2.6/dialog/oauth',
+  'https://www.facebook.com/logout.php',
+  'https://www.facebook.com/logout.php?next=https://code.org/&access_token=XXXXXX|YYYYYYYYYYYY|ZZZZZZ',
 ];
 
-const BLACKLISTED_ORIGINS = [
+const BLACKLISTED_PAGES = [
   'https://curriculum.code.org',
   'https://docs.code.org',
   'https://forum.code.org',
   'https://support.code.org',
   'https://wiki.code.org',
+  'https://www.google.com',
+  'https://www.facebook.com',
 ];
+
+function originFromUrl(url) {
+  return new URL(url).origin;
+}
 
 describe('openUrlInDefaultBrowser', () => {
   // These should load in the system default browser
   [
-    ...BLACKLISTED_ORIGINS,
-  ].forEach((origin) => {
-    it(`true for ${origin}`, () => {
-      expect(openUrlInDefaultBrowser(`${origin}/any/test/path`)).to.be.true;
+    ...BLACKLISTED_PAGES,
+  ].forEach((url) => {
+    it(`true for ${url}`, () => {
+      expect(openUrlInDefaultBrowser(url)).to.be.true;
     });
   });
 
-  // These should load within Maker Toolkit
+  // These should load within Maker Toolkit Browser
   [
-    ...WHITELISTED_INTERNAL_ORIGINS,
-    ...WHITELISTED_EXTERNAL_ORIGINS,
-  ].forEach((origin) => {
-    it(`false for ${origin}`, () => {
-      expect(openUrlInDefaultBrowser(`${origin}/any/test/path`)).to.be.false;
+    ...WHITELISTED_INTERNAL_PAGES,
+    ...WHITELISTED_EXTERNAL_PAGES,
+  ].forEach((url) => {
+    it(`false for ${url}`, () => {
+      expect(openUrlInDefaultBrowser(url)).to.be.false;
     });
   });
 });
@@ -56,20 +69,24 @@ describe('openUrlInDefaultBrowser', () => {
 describe('mayInjectNativeApi', () => {
   // These should get the native APIs injected into the page
   [
-    ...WHITELISTED_INTERNAL_ORIGINS,
-  ].forEach((origin) => {
-    it(`allows ${origin}`, () => {
-      expect(mayInjectNativeApi(origin)).to.be.true;
+    ...WHITELISTED_INTERNAL_PAGES,
+  ]
+    .map(originFromUrl)
+    .forEach((origin) => {
+      it(`allows ${origin}`, () => {
+        expect(mayInjectNativeApi(origin)).to.be.true;
+      });
     });
-  });
 
   // These should never get native APIs injected into the page
   [
-    ...WHITELISTED_EXTERNAL_ORIGINS,
-    ...BLACKLISTED_ORIGINS,
-  ].forEach((origin) => {
-    it(`blocks ${origin}`, () => {
-      expect(mayInjectNativeApi(origin)).to.be.false;
+    ...WHITELISTED_EXTERNAL_PAGES,
+    ...BLACKLISTED_PAGES,
+  ]
+    .map(originFromUrl)
+    .forEach((origin) => {
+      it(`blocks ${origin}`, () => {
+        expect(mayInjectNativeApi(origin)).to.be.false;
+      });
     });
-  });
 });

--- a/test/originWhitelistTest.js
+++ b/test/originWhitelistTest.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const { expect } = require('chai');
 const {URL} = require('url');
 const {
@@ -68,25 +69,25 @@ describe('openUrlInDefaultBrowser', () => {
 
 describe('mayInjectNativeApi', () => {
   // These should get the native APIs injected into the page
-  [
-    ...WHITELISTED_INTERNAL_PAGES,
-  ]
-    .map(originFromUrl)
-    .forEach((origin) => {
-      it(`allows ${origin}`, () => {
-        expect(mayInjectNativeApi(origin)).to.be.true;
-      });
+  _.uniq(
+    [
+      ...WHITELISTED_INTERNAL_PAGES,
+    ].map(originFromUrl)
+  ).forEach((origin) => {
+    it(`allows ${origin}`, () => {
+      expect(mayInjectNativeApi(origin)).to.be.true;
     });
+  });
 
   // These should never get native APIs injected into the page
-  [
-    ...WHITELISTED_EXTERNAL_PAGES,
-    ...BLACKLISTED_PAGES,
-  ]
-    .map(originFromUrl)
-    .forEach((origin) => {
-      it(`blocks ${origin}`, () => {
-        expect(mayInjectNativeApi(origin)).to.be.false;
-      });
+  _.uniq(
+    [
+      ...WHITELISTED_EXTERNAL_PAGES,
+      ...BLACKLISTED_PAGES,
+    ].map(originFromUrl)
+  ).forEach((origin) => {
+    it(`blocks ${origin}`, () => {
+      expect(mayInjectNativeApi(origin)).to.be.false;
     });
+  });
 });

--- a/test/originWhitelistTest.js
+++ b/test/originWhitelistTest.js
@@ -1,10 +1,10 @@
 const { expect } = require('chai');
 const {
-  isOriginWhitelisted,
-  isUrlWhitelisted,
+  openUrlInDefaultBrowser,
+  mayInjectNativeApi,
 } = require('../src/originWhitelist');
 
-const WHITELISTED_ORIGINS = [
+const WHITELISTED_INTERNAL_ORIGINS = [
   // Production
   'https://code.org',
   'https://studio.code.org',
@@ -17,6 +17,9 @@ const WHITELISTED_ORIGINS = [
   // Local development
   'http://localhost.code.org:3000',
   'http://localhost-studio.code.org:3000',
+];
+
+const WHITELISTED_EXTERNAL_ORIGINS = [
   // Google OAuth
   'https://accounts.google.com',
 ];
@@ -29,30 +32,44 @@ const BLACKLISTED_ORIGINS = [
   'https://wiki.code.org',
 ];
 
-describe('isOriginWhitelisted', () => {
-  WHITELISTED_ORIGINS.forEach((origin) => {
-    it(`allows ${origin}`, () => {
-      expect(isOriginWhitelisted(origin)).to.be.true;
+describe('openUrlInDefaultBrowser', () => {
+  // These should load in the system default browser
+  [
+    ...BLACKLISTED_ORIGINS,
+  ].forEach((origin) => {
+    it(`true for ${origin}`, () => {
+      expect(openUrlInDefaultBrowser(`${origin}/any/test/path`)).to.be.true;
     });
   });
 
-  BLACKLISTED_ORIGINS.forEach((origin) => {
-    it(`blocks ${origin}`, () => {
-      expect(isOriginWhitelisted(origin)).to.be.false;
+  // These should load within Maker Toolkit
+  [
+    ...WHITELISTED_INTERNAL_ORIGINS,
+    ...WHITELISTED_EXTERNAL_ORIGINS,
+  ].forEach((origin) => {
+    it(`false for ${origin}`, () => {
+      expect(openUrlInDefaultBrowser(`${origin}/any/test/path`)).to.be.false;
     });
   });
 });
 
-describe('isUrlWhitelisted', () => {
-  WHITELISTED_ORIGINS.forEach((origin) => {
+describe('mayInjectNativeApi', () => {
+  // These should get the native APIs injected into the page
+  [
+    ...WHITELISTED_INTERNAL_ORIGINS,
+  ].forEach((origin) => {
     it(`allows ${origin}`, () => {
-      expect(isUrlWhitelisted(`${origin}/any/test/path`)).to.be.true;
+      expect(mayInjectNativeApi(origin)).to.be.true;
     });
   });
 
-  BLACKLISTED_ORIGINS.forEach((origin) => {
+  // These should never get native APIs injected into the page
+  [
+    ...WHITELISTED_EXTERNAL_ORIGINS,
+    ...BLACKLISTED_ORIGINS,
+  ].forEach((origin) => {
     it(`blocks ${origin}`, () => {
-      expect(isUrlWhitelisted(`${origin}/any/test/path`)).to.be.false;
+      expect(mayInjectNativeApi(origin)).to.be.false;
     });
   });
 });

--- a/test/originWhitelistTest.js
+++ b/test/originWhitelistTest.js
@@ -17,6 +17,8 @@ const WHITELISTED_ORIGINS = [
   // Local development
   'http://localhost.code.org:3000',
   'http://localhost-studio.code.org:3000',
+  // Google OAuth
+  'https://accounts.google.com',
 ];
 
 const BLACKLISTED_ORIGINS = [


### PR DESCRIPTION
Whitelists OAuth login/logout URLs, while blacklisting facebook.com generally, so that we can support Facebook login to Code.org but otherwise open Facebook in the default browser.

New/changed tests:
```
  openUrlInDefaultBrowser
    ✓ true for https://www.google.com
    ✓ true for https://www.facebook.com
    ✓ false for https://accounts.google.com
    ✓ false for https://accounts.google.com/signin/oauth
    ✓ false for https://accounts.google.com/logout
    ✓ false for https://www.facebook.com/v2.6/dialog/oauth
    ✓ false for https://www.facebook.com/logout.php
    ✓ false for https://www.facebook.com/logout.php?next=https://code.org/&access_token=XXXXXX|YYYYYYYYYYYY|ZZZZZZ

  mayInjectNativeApi
    ✓ blocks https://accounts.google.com
    ✓ blocks https://www.facebook.com
    ✓ blocks https://www.google.com

```