### PR TITLE
Add Windows and Linux build targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "start": "NODE_ENV=${NODE_ENV:-development} electron .",
     "pack": "build --dir",
     "predist": "yarn test",
-    "dist": "build"
+    "dist": "build",
+    "win": "build --win",
+    "linux": "build --linux"
   },
   "build": {
     "appId": "com.electron.code-dot-org-browser",


### PR DESCRIPTION
At least on my machine, I have to add specific targets to build Linux and Mac locally (on OS X)