### PR TITLE
CI yarn with --frozen-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
 
 install:
   - nvm install 8
-  - yarn install
+  - yarn install --frozen-lockfile
 
 script:
   - yarn run dist


### PR DESCRIPTION
Use yarn's `--frozen-lockfile` flag when running `yarn install` in CI, so that the build fails if `yarn install` would generate any changes to the lockfile.