### PR TITLE
Clever Login Button

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -17,6 +17,7 @@ const {
 const {
   HOME_URL,
   MAKER_SETUP_URL,
+  CLEVER_LOGIN_URL,
 } = require('./defaults');
 
 window.onresize = doLayout;
@@ -72,6 +73,10 @@ window.onload = function() {
 
   document.querySelector('#setup').onclick = function() {
     navigateTo(MAKER_SETUP_URL);
+  };
+
+  document.querySelector('#clever-login').onclick = function() {
+    navigateTo(CLEVER_LOGIN_URL);
   };
 
   webview.addEventListener('close', handleExit);

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -9,4 +9,5 @@ const DASHBOARD_HOST = process.env.DASHBOARD_HOST || (
 module.exports = {
   HOME_URL: DASHBOARD_HOST + '/home',
   MAKER_SETUP_URL: DASHBOARD_HOST + '/maker/setup',
+  CLEVER_LOGIN_URL: 'https://clever.com/login',
 };

--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,7 @@
     <button id="home" title="Go Home">&#8962;</button>
     <button id="reload" title="Reload">&#10227;</button>
     <button id="setup" title="Setup">&#x2699;</button>
+    <button id="clever-login" title="Log in with Clever">Log in with Clever</button>
   </div>
 
   <webview preload="./preload.js" partition="persist:code-dot-org-browser"></webview>

--- a/src/originWhitelist.js
+++ b/src/originWhitelist.js
@@ -44,6 +44,8 @@ const EXTERNAL_WHITELIST = [
   /\/\/www\.facebook\.com\/logout/i,
   // Microsoft OAuths
   /\/\/login\.live\.com(?:$|\/)/i,
+  // Clever Auth
+  /\/\/clever.com\/(?:in|login|oauth)(?:$|\/)/i,
 ];
 
 /**

--- a/test/originWhitelistTest.js
+++ b/test/originWhitelistTest.js
@@ -26,13 +26,25 @@ const WHITELISTED_EXTERNAL_PAGES = [
   'https://accounts.google.com',
   'https://accounts.google.com/signin/oauth',
   'https://accounts.google.com/logout',
+
   // Facebook OAuth
   'https://www.facebook.com/v2.6/dialog/oauth',
   'https://www.facebook.com/logout.php',
   'https://www.facebook.com/logout.php?next=https://code.org/&access_token=XXXXXX|YYYYYYYYYYYY|ZZZZZZ',
+
   // Microsoft OAuth
   'https://login.live.com/oauth20_authorize.srf',
   'http://login.live.com/logout.srf',
+
+  // Clever Log-in flow
+  // Generic portal link
+  'https://clever.com/login',
+  // School-specific portal link
+  'https://clever.com/in/codeorg-clever-dev',
+  // Auth flow URLs
+  'https://clever.com/oauth/sis/login?target=secret&skip=1&school_name=&default_badge=',
+  'https://clever.com/oauth/authorize?response_type=code&state=secret&redirect_uri=https%3A%2F%2Fclever.com%2Fin%2Fauth_callback&client_id=secret&confirmed=true&channel=clever&new_login_flow=true&district_id=secret',
+  'https://clever.com/in/auth_callback?code=secret&scope=read%3Adistrict_admins_limited%20read%3Aschool_admins_limited%20read%3Asections_limited%20read%3Astudents_launchpad%20read%3Astudents_limited%20read%3Ateachers_limited%20read%3Auser_id&state=secret',
 ];
 
 const BLACKLISTED_PAGES = [


### PR DESCRIPTION
Adds a Clever.com login button to the Maker Browser toolbar and whitelists Clever login flow URLs, so that it's possible to sign in to Code.org via Clever within the Maker Browser.

![image](https://user-images.githubusercontent.com/1615761/34967307-884b9088-fa16-11e7-8351-e77cb0df521e.png)

Design-wise this is a little clumsy right now, but getting it functional is the first priority.

## Login Flow

Clicking the button takes the student to the District login page, if they've signed in using Maker Browser before...
![image](https://user-images.githubusercontent.com/1615761/34967340-c2ffa6f6-fa16-11e7-922f-37778830e7c1.png)

Or this generic login page if they have not (which includes a working Clever Badge login option):
![image](https://user-images.githubusercontent.com/1615761/34967371-06585556-fa17-11e7-8224-81e07a18f7c2.png)

Once signed in to Clever students will see their apps on Clever's site within Maker Browser:
![pasted image at 2018_01_15 04_53 pm](https://user-images.githubusercontent.com/1615761/34967378-202ffd76-fa17-11e7-90fe-bd372b4d6acf.png)

And can click on Code.org to get signed in:
![pasted image at 2018_01_15 04_54 pm](https://user-images.githubusercontent.com/1615761/34967383-298928b6-fa17-11e7-928f-2ceb31ce819c.png)



