### PR TITLE
Enable 32 bit builds

### DIFF
--- a/config/_release.json
+++ b/config/_release.json
@@ -8,10 +8,6 @@
       "provider": "s3",
       "bucket": "downloads.code.org",
       "path": "makertoolkit"
-    },
-    {
-      "provider": "github",
-      "releaseType": "release"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-dot-org-browser",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A browser with Code.org-specific extensions, built with Electron",
   "homepage": "https://code.org",
   "repository": "https://github.com/code-dot-org/browser",
@@ -23,7 +23,7 @@
     "win": "build --win",
     "linux": "build --linux",
     "prerelease": "yarn generate-config",
-    "release": "build --win --mac --linux --config ./config/release.json --publish always"
+    "release": "build --win --x64 --ia32 --mac --linux --config ./config/release.json --publish always"
   },
   "dependencies": {
     "electron-log": "^1.3.0",


### PR DESCRIPTION
Also disables Github releases, because something goes wrong when uploading all the artifacts in parallel. Looking into reenabling that in a separate PR.