### PR TITLE
Add edit menu, enable copy/paste

### DIFF
--- a/src/menus.js
+++ b/src/menus.js
@@ -111,17 +111,32 @@ module.exports = function setupMenus() {
     role: 'help',
   };
 
+  const editMenu = {
+    label: "Edit",
+    submenu: [
+      { label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:" },
+      { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", selector: "redo:" },
+      { type: "separator" },
+      { label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:" },
+      { label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
+      { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
+      { label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:" }
+    ]
+  };
+
   // We define menus differently on OSX:
   let menu;
   if (process.platform === 'darwin') {
     menu = Menu.buildFromTemplate([
       osxAppMenu,
+      editMenu,
       viewMenu,
       osxHelpMenu,
     ]);
   } else {
     menu = Menu.buildFromTemplate([
       fileMenu,
+      editMenu,
       viewMenu,
       helpMenu,
     ]);

--- a/src/menus.js
+++ b/src/menus.js
@@ -120,8 +120,8 @@ module.exports = function setupMenus() {
       { label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
       { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
       { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
-      { label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:' }
-    ]
+      { label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:' },
+    ],
   };
 
   // We define menus differently on OSX:

--- a/src/menus.js
+++ b/src/menus.js
@@ -112,15 +112,15 @@ module.exports = function setupMenus() {
   };
 
   const editMenu = {
-    label: "Edit",
+    label: 'Edit',
     submenu: [
-      { label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:" },
-      { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", selector: "redo:" },
-      { type: "separator" },
-      { label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:" },
-      { label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
-      { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
-      { label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:" }
+      { label: 'Undo', accelerator: 'CmdOrCtrl+Z', selector: 'undo:' },
+      { label: 'Redo', accelerator: 'Shift+CmdOrCtrl+Z', selector: 'redo:' },
+      { type: 'separator' },
+      { label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
+      { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
+      { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
+      { label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:' }
     ]
   };
 


### PR DESCRIPTION
Based on https://pracucci.com/atom-electron-enable-copy-and-paste.html - seems to Just Work(tm) on OS X:

<img width="556" alt="screen shot 2018-01-23 at 8 42 02 am" src="https://user-images.githubusercontent.com/70630/35288358-52afed9e-0019-11e8-82bb-40090fdad5cc.png">
