### PR TITLE
Toolbar shouldn't be selectable

### DIFF
--- a/src/browser.css
+++ b/src/browser.css
@@ -13,6 +13,8 @@ input {
     padding: 3px;
     border-bottom: solid 1px #ccc;
     background-color: #eee;
+    /* Shouldn't be able to text-select toolbar buttons. */
+    user-select: none;
 }
 
 #controls button,


### PR DESCRIPTION
While testing the addition of cut/copy/paste/select-all hotkeys, I noticed that it's possible to select the buttons in the browser toolbar.  We probably don't want to allow that, so I'm disabling it.