### PR TITLE
Enforce code signing when publishing

### DIFF
--- a/config/_release.json
+++ b/config/_release.json
@@ -1,4 +1,5 @@
 {
+  "forceCodeSigning": true,
   "publish": [
     {
       "provider": "generic",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-dot-org-browser",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A browser with Code.org-specific extensions, built with Electron",
   "homepage": "https://code.org",
   "repository": "https://github.com/code-dot-org/browser",


### PR DESCRIPTION
This enforces code signing when trying to publish a build, to avoid mistakes like I made yesterday when I forgot to set my environment variables to pull in the signing keys.

This should not affect local builds, as the forceCodeSigning key is only pulled in when using the release config.

Also bumps version to 1.0.4