### PR TITLE
Improve the "Open URL" modal

### DIFF
--- a/src/openUrlModal/index.js
+++ b/src/openUrlModal/index.js
@@ -23,7 +23,7 @@ function showOpenUrlModal() {
 
   const modal = new BrowserWindow({
     width: 360,
-    height: 70,
+    height: 80,
     show: false,
     parent: _mainWindow,
     modal: true,

--- a/src/openUrlModal/view.css
+++ b/src/openUrlModal/view.css
@@ -23,6 +23,10 @@ body {
     margin-top: 4px;
 }
 
+#cancel-button {
+    margin-right: 0.2em;
+}
+
 #go-button {
     flex-grow: 0;
     line-height: 14pt;

--- a/src/openUrlModal/view.html
+++ b/src/openUrlModal/view.html
@@ -10,6 +10,7 @@
     </div>
     <div class="flex-row">
         <span id="error-feedback"></span>
+        <input type="button" id="cancel-button" value="Cancel"/>
         <input type="button" id="go-button" value="Go"/>
     </div>
 </body>

--- a/src/openUrlModal/view.js
+++ b/src/openUrlModal/view.js
@@ -9,6 +9,7 @@ function onLoad() {
 
   const urlInput = document.getElementById('url-input');
   const errorFeedback = document.getElementById('error-feedback');
+  const cancelButton = document.getElementById('cancel-button');
   const goButton = document.getElementById('go-button');
 
   /**
@@ -54,6 +55,7 @@ function onLoad() {
 
   urlInput.addEventListener('keyup', checkUrl);
   urlInput.addEventListener('change', checkUrl);
+  cancelButton.addEventListener('click', () => window.close());
   goButton.addEventListener('click', submit);
 
   window.addEventListener('keydown', (event) => {


### PR DESCRIPTION
Two changes to mitigate problems with this dialog on OSX (before image):
![image](https://user-images.githubusercontent.com/1615761/36234397-a175e0e0-119f-11e8-8639-8beeded86d96.png)

- Adds a "Cancel" button - apparently on OSX there isn't a close button on the window by default.
- Makes the modal a little taller.

New appearance on Ubuntu/Gnome:
![image](https://user-images.githubusercontent.com/1615761/36234372-7e3c604a-119f-11e8-8866-ef08affee145.png)

I'd appreciate verification on OSX since I don't have access to it.

([Axosoft item 1269: Fix UI for entering arbitrary URL UI](https://codeorg.axosoft.com/viewitem?id=1269&type=features&force_use_number=true))