### PR TITLE
HOME is now the new maker homepage

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -7,7 +7,7 @@ const DASHBOARD_HOST = process.env.DASHBOARD_HOST || (
 );
 
 module.exports = {
-  HOME_URL: DASHBOARD_HOST + '/home',
+  HOME_URL: DASHBOARD_HOST + '/maker/home',
   MAKER_SETUP_URL: DASHBOARD_HOST + '/maker/setup',
   CLEVER_LOGIN_URL: 'https://clever.com/login',
 };


### PR DESCRIPTION
Turns out this was super-easy to do, but I don't want to ship this until at least https://github.com/code-dot-org/code-dot-org/pull/20804 ships, and maybe a couple follow-up items I have close on its heels.

Note, this changes the default page loaded on launch, and where we navigate when you click the HOME button.  In both cases if you are not signed in, you'll be redirected to the sign-in page, which will redirect you back to /maker/home after auth.
