### PR TITLE
Whitelist sso.pcsd1.org

### DIFF
--- a/src/originWhitelist.js
+++ b/src/originWhitelist.js
@@ -46,6 +46,8 @@ const EXTERNAL_WHITELIST = [
   /\/\/login\.live\.com(?:$|\/)/i,
   // Clever Auth
   /\/\/clever.com\/(?:in|login|oauth)(?:$|\/)/i,
+  // School- and District-specific portals
+  /\/\/sso.pcsd1.org(?:$|\/)/i,
 ];
 
 /**

--- a/test/originWhitelistTest.js
+++ b/test/originWhitelistTest.js
@@ -45,6 +45,9 @@ const WHITELISTED_EXTERNAL_PAGES = [
   'https://clever.com/oauth/sis/login?target=secret&skip=1&school_name=&default_badge=',
   'https://clever.com/oauth/authorize?response_type=code&state=secret&redirect_uri=https%3A%2F%2Fclever.com%2Fin%2Fauth_callback&client_id=secret&confirmed=true&channel=clever&new_login_flow=true&district_id=secret',
   'https://clever.com/in/auth_callback?code=secret&scope=read%3Adistrict_admins_limited%20read%3Aschool_admins_limited%20read%3Asections_limited%20read%3Astudents_launchpad%20read%3Astudents_limited%20read%3Ateachers_limited%20read%3Auser_id&state=secret',
+
+  // Known school- and district-specific SSO portals
+  'https://sso.pcsd1.org',
 ];
 
 const BLACKLISTED_PAGES = [


### PR DESCRIPTION
Requested independently in two Zendesk tickets:

- https://codeorg.zendesk.com/agent/tickets/135552
- https://codeorg.zendesk.com/agent/tickets/134994

It would be preferable not to handle school-specific URLs here but we don't currently have a good workaround.

I'm not entirely sure this will solve the problem for this district, as I don't have details on their OAuth flow beyond the origin they supplied.  Rather than asking them to track the whole series of redirects involved from their end, I think we should release this quick fix and ask them to test it.  In the meantime we should set up metrics on whitelist misses that will make this easier to diagnose/fix from our end in the future.