### PR TITLE
Whitelist GSuite URL

### DIFF
--- a/src/originWhitelist.js
+++ b/src/originWhitelist.js
@@ -39,6 +39,8 @@ const INTERNAL_BLACKLIST = [
 const EXTERNAL_WHITELIST = [
   // Google OAuth
   /\/\/accounts\.google\.com(?:$|\/)/i,
+  // Google GSuite prefix sometimes used for district-specific redirects.
+  /\/\/www\.google\.com\/a\//i,
   // Facebook OAuth
   /\/\/www\.facebook\.com\/v2.6\/dialog\/oauth/i,
   /\/\/www\.facebook\.com\/logout/i,

--- a/test/originWhitelistTest.js
+++ b/test/originWhitelistTest.js
@@ -48,6 +48,7 @@ const WHITELISTED_EXTERNAL_PAGES = [
 
   // Known school- and district-specific SSO portals
   'https://sso.pcsd1.org',
+  'https://www.google.com/a/pcsd1.org/acs',
 ];
 
 const BLACKLISTED_PAGES = [


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/browser/pull/33 still trying to unblock PCSD1. We got a [response in Zendesk](https://codeorg.zendesk.com/agent/tickets/135552) today saying:

> We do get one step further along. We are able to hit our SSO portal page within the Toolkit browser now. Once we hit “sign in” we are booted out and appear to land on accounts.google.com which I know is in your whitelist already. I did a little digging and I think there is an intermediate redirect that is kicking us out:
> 
> https://www.google.com/a/pcsd1.org/acs

That would definitely do it.   I might be whitelisting all of GSuite here (`https://www.google.com/a/` redirects to `https://gsuite.google.com/`) or maybe just the GSuite admin pages, but that seems like a reasonable starting point - the whitelist is about constraining the user experience anyway, not security.