### PR TITLE
Add manual update popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-dot-org-browser",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A browser with Code.org-specific extensions, built with Electron",
   "homepage": "https://code.org",
   "repository": "https://github.com/code-dot-org/browser",

--- a/src/checkForManualUpdate.js
+++ b/src/checkForManualUpdate.js
@@ -1,0 +1,26 @@
+const {app, dialog, shell} = require('electron');
+
+function checkForManualUpdate() {
+  manualUpdate = app.getVersion().startsWith('1.0.9');
+  if (manualUpdate) {
+    dialog.showMessageBox(
+      {
+        type: 'info',
+        buttons: ['Download Now', 'Cancel'],
+        title: 'Update Available',
+        message: 'An update is available, would you like to download it now?',
+        detail: 'If you have already installed the new version (Code.org Maker App) and are still seeing this message, you may need to delete the old one (Maker Toolkit) from your system.',
+        cancelId: 1,
+      },
+      (response, _) => {
+        if (response === 0) {
+          shell.openExternal("https://studio.code.org/maker/setup");
+          app.quit();
+        }
+      }
+    );
+  }
+  return manualUpdate;
+}
+
+module.exports = checkForManualUpdate;

--- a/src/checkForManualUpdate.js
+++ b/src/checkForManualUpdate.js
@@ -1,7 +1,7 @@
 const {app, dialog, shell} = require('electron');
 
 function checkForManualUpdate() {
-  manualUpdate = app.getVersion().startsWith('1.0.9');
+  const manualUpdate = app.getVersion().startsWith('1.0.9');
   if (manualUpdate) {
     dialog.showMessageBox(
       {
@@ -14,7 +14,7 @@ function checkForManualUpdate() {
       },
       (response, _) => {
         if (response === 0) {
-          shell.openExternal("https://studio.code.org/maker/setup");
+          shell.openExternal('https://studio.code.org/maker/setup');
           app.quit();
         }
       }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const {app, dialog, shell, BrowserWindow} = require('electron');
+const {app, BrowserWindow} = require('electron');
 const path = require('path');
 const url = require('url');
 const setupMenus = require('./menus');


### PR DESCRIPTION
Detects if the user is running 1.0.9, and if so, prompts them to manually download a new version.

<img width="463" alt="screen shot 2018-03-05 at 12 46 34 pm" src="https://user-images.githubusercontent.com/70630/37066943-751615ac-215c-11e8-867d-758262e74f20.png">

The deployment plan is that we'll publish this as 1.0.9, and then immediately publish 1.1.0 with the branding update in https://github.com/code-dot-org/browser/pull/31 (which users will not be able to auto-update to).

Note that this also disables the auto-update check on 1.0.9, because based on testing, once the newer version is pushed with a different package name, every auto-update check will download the whole update and then fail to install it.

