### PR TITLE
Move S3 directory for 1.1.x releases

### DIFF
--- a/config/_release.json
+++ b/config/_release.json
@@ -3,12 +3,12 @@
   "publish": [
     {
       "provider": "generic",
-      "url": "https://downloads.code.org/makertoolkit/"
+      "url": "https://downloads.code.org/maker/"
     },
     {
       "provider": "s3",
       "bucket": "downloads.code.org",
-      "path": "makertoolkit"
+      "path": "maker"
     }
   ]
 }


### PR DESCRIPTION
To match rebranding, we change the download location from makertoolkit -> maker.

This is related to #31, so we could make sure that the 1.0.x line doesn't try to update into the 1.1.x line (which will fail because of the package name change).