### PR TITLE
Enable multi-user install on Windows, bump to 1.1.2

### DIFF
--- a/config/_common.json
+++ b/config/_common.json
@@ -3,6 +3,9 @@
   "productName": "Code.org Maker App",
   "artifactName": "${productName}-${version}-${os}.${ext}",
   "copyright": "Copyright © 2017 Code.org",
+  "nsis": {
+    "oneClick": false
+  },
   "mac": {
     "category": "public.app-category.education"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-dot-org-browser",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A browser with Code.org-specific extensions, built with Electron",
   "homepage": "https://code.org",
   "repository": "https://github.com/code-dot-org/browser",


### PR DESCRIPTION
Flips the switch on one-click install to "false" on Windows to enable per-machine installation.