### PR TITLE
Whitelist google.com/accounts for redirects

### DIFF
--- a/src/originWhitelist.js
+++ b/src/originWhitelist.js
@@ -39,10 +39,11 @@ const INTERNAL_BLACKLIST = [
 const EXTERNAL_WHITELIST = [
   // Google OAuth
   /\/\/accounts\.google\.com(?:$|\/)/i,
+  /\/\/www\.google\.com\/accounts\//i,
   // Google GSuite prefix sometimes used for district-specific redirects.
   /\/\/www\.google\.com\/a\//i,
   // Facebook OAuth
-  /\/\/www\.facebook\.com\/v2.6\/dialog\/oauth/i,
+  /\/\/www\.facebook\.com\/v[^/]+\/dialog\/oauth/i,
   /\/\/www\.facebook\.com\/logout/i,
   // Microsoft OAuths
   /\/\/login\.live\.com(?:$|\/)/i,

--- a/test/originWhitelistTest.js
+++ b/test/originWhitelistTest.js
@@ -25,7 +25,9 @@ const WHITELISTED_EXTERNAL_PAGES = [
   // Google OAuth
   'https://accounts.google.com',
   'https://accounts.google.com/signin/oauth',
+  'https://accounts.google.com/signin/oauth/consent',
   'https://accounts.google.com/logout',
+  'https://www.google.com/accounts/signin/continue?sarp=1&continue=https%3A%2F%2Faccounts.google.com%2Fsignin%2Foauth%2Fconsent',
 
   // Facebook OAuth
   'https://www.facebook.com/v2.6/dialog/oauth',


### PR DESCRIPTION
We got a report of an OAuth redirect sequence that goes through `www.google.com/accounts/signin/continue` (instead of `accounts.google.com/signin/oauth` like the paths we've observed so far).  Expanding the whitelist to include that path.