### PR TITLE
Disable whitelist check during oauth flow

### DIFF
--- a/src/originWhitelist.js
+++ b/src/originWhitelist.js
@@ -13,7 +13,7 @@ const {URL} = require('url');
 // https://test-studio.code.org                     Test
 // https://dashboard-adhoc-my-branch.cdn-code.org   Ad-Hoc servers
 // http://localhost-studio.code.org:3000            Local development
-const CODE_ORG_URL = /^https?:\/\/(?:[\w\d-]+\.)?(?:cdn-)?code\.org(?::\d+)?$/i;
+const CODE_ORG_URL = /^http(?:s)?:\/\/(?:[\w\d-]+\.)?(?:cdn-)?code\.org(?::\d+)?$/i;
 
 /**
  * Navigation to urls matching any of the given origins will open the page in
@@ -82,7 +82,13 @@ function urlIsOnExternalWhitelist(url) {
   return EXTERNAL_WHITELIST.some(site => site.test(url));
 }
 
+function isCodeOrgUrl(url) {
+  const origin = new URL(url).origin;
+  return CODE_ORG_URL.test(origin);
+}
+
 module.exports = {
+  isCodeOrgUrl,
   openUrlInDefaultBrowser,
   mayInjectNativeApi,
 };

--- a/src/originWhitelist.js
+++ b/src/originWhitelist.js
@@ -13,7 +13,7 @@ const {URL} = require('url');
 // https://test-studio.code.org                     Test
 // https://dashboard-adhoc-my-branch.cdn-code.org   Ad-Hoc servers
 // http://localhost-studio.code.org:3000            Local development
-const CODE_ORG_URL = /^http(?:s)?:\/\/(?:[\w\d-]+\.)?(?:cdn-)?code\.org(?::\d+)?$/i;
+const CODE_ORG_URL = /^https?:\/\/(?:[\w\d-]+\.)?(?:cdn-)?code\.org(?::\d+)?$/i;
 
 /**
  * Navigation to urls matching any of the given origins will open the page in


### PR DESCRIPTION
To get away from having to support an ever-growing list of per-school whitelisted domains for oauth, we just skip the whitelist check altogether during the oauth process.