### PR TITLE
Add Firehose logging for metrics reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "electron-log": "^1.3.0",
     "electron-updater": "^2.15.0",
     "lodash": "^4.17.4",
-    "serialport": "6.0.4"
+    "serialport": "6.0.4",
+    "aws-sdk": "2.28.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -1,0 +1,190 @@
+/** @file Provides clients to AWS Firehose, whose data is imported into AWS Redshift. */
+
+const AWS = require('aws-sdk');
+const {createUuid, trySetLocalStorage, tryGetLocalStorage} = require('./utils');
+const {app, BrowserWindow} = require('electron');
+
+/**
+ * Adapted from https://github.com/code-dot-org/code-dot-org/blob/54ab514aafdd2651e6232b1b51c8281b3a93a851/apps/src/lib/util/firehose.js
+ * A barebones client for posting data to an AWS Firehose stream.
+ * Usage:
+ *   firehoseClient.putRecord(
+ *     {
+ *       study: 'underwater basket weaving', // REQUIRED
+ *       study_group: 'control',             // OPTIONAL
+ *       event: 'drowning',                  // REQUIRED
+ *       data_int: 2                         // OPTIONAL
+ *       data_float: 0.31                    // OPTIONAL
+ *       data_string: 'code.org rocks'       // OPTIONAL
+ *       data_json: JSON.stringify(x)        // OPTIONAL
+ *     }
+ *   );
+ * Usage:
+ *   firehoseClient.putRecordBatch(
+ *     [
+ *       {
+ *         study: 'underwater basket weaving', // REQUIRED
+ *         study_group: 'control',             // OPTIONAL
+ *         event: 'drowning',                  // REQUIRED
+ *         data_int: 2                         // OPTIONAL
+ *         data_float: 0.31                    // OPTIONAL
+ *         data_string: 'code.org rocks'       // OPTIONAL
+ *         data_json: JSON.stringify(x)        // OPTIONAL
+ *       },
+ *       {
+ *         study: 'underwater basket weaving', // REQUIRED
+ *         study_group: 'control',             // OPTIONAL
+ *         event: 'drowning',                  // REQUIRED
+ *         data_int: 2                         // OPTIONAL
+ *         data_float: 0.31                    // OPTIONAL
+ *         data_string: 'code.org rocks'       // OPTIONAL
+ *         data_json: JSON.stringify(x)        // OPTIONAL
+ *       },
+ *     ]
+ *   );
+ */
+
+const deliveryStreamName = 'analysis-events';
+let analytics_uuid = null;
+
+// TODO(asher): Add the ability to queue records individually, to be submitted
+// as a batch.
+// TODO(asher): Determine whether any of the utility functions herein should be
+// moved elsewhere, e.g., to apps/src/util.js.
+class FirehoseClient {
+  /**
+   * Returns the current environment.
+   * @return {string} The current environment, e.g., "staging" or "production".
+   */
+  getEnvironment() {
+    return process.env.NODE_ENV;
+  }
+
+  /**
+   * Returns whether the environment appears to be the test environment.
+   * @return {boolean} Whether the hostname includes "test".
+   */
+  isTestEnvironment() {
+    return this.getEnvironment() === "test";
+  }
+
+  /**
+   * Returns whether the environment appears to be a development environment.
+   * @return {boolean} Whether the hostname includes "localhost".
+   */
+  isDevelopmentEnvironment() {
+    return this.getEnvironment() === "development";
+  }
+
+  /**
+   * Returns whether the request should be sent through to AWS Firehose.
+   * @param {boolean} alwaysPut An override to default environment behavior.
+   * @return {boolean} Whether the request should be sent through to AWS
+   *   Firehose.
+   */
+  shouldPutRecord(alwaysPut) {
+    if (alwaysPut) {
+      return true;
+    }
+    if (this.isTestEnvironment() || this.isDevelopmentEnvironment()) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns a unique user ID that is persisted across sessions through local
+   * storage.
+   * WARNING: Mutates local storage if an analyticsID has not already been set.
+   * @return {string} A unique user ID.
+   */
+  getAnalyticsUuid() {
+    if (!analytics_uuid) {
+      analytics_uuid = createUuid();
+    }
+    return analytics_uuid;
+  }
+
+  /**
+   * Returns a hash containing user device information.
+   * storage.
+   * @return {hash} Hash of user device information.
+   */
+  getDeviceInfo() {
+    const focusedWindow = BrowserWindow.getFocusedWindow();
+    let device_info = {
+      platform: process.platform,
+      version: app.getVersion(),
+    };
+    if (focusedWindow) {
+      device_info = Object.assign({},
+        device_info,
+        {
+          window_width: focusedWindow.getBounds().width,
+          window_height: focusedWindow.getBounds().height,
+        }
+      );
+    }
+    return device_info;
+  }
+
+  /**
+   * Merge various key-value pairs into data.
+   * @param {hash} data The data to add the key-value pairs to.
+   * @option {boolean} includeUserId Include userId in records, if signed in
+   * @return {hash} The data, including the newly added key-value pairs.
+   */
+  addCommonValues(data) {
+    data['created_at'] = new Date().toISOString();
+    data['environment'] = this.getEnvironment();
+    data['uuid'] = this.getAnalyticsUuid();
+    data['device'] = JSON.stringify(this.getDeviceInfo());
+
+    return data;
+  }
+
+  /**
+   * Pushes one data record into the delivery stream.
+   * @param {hash} data The data to push.
+   * @param {hash} options Additional (optional) options.
+   *   (default {alwaysPut: false})
+   * @option options [boolean] alwaysPut Forces the record to be sent.
+   * @option options [boolean] includeUserId Include userId in records, if signed in
+   * @option options [function(err, data)] callback Invoked upon completion with error or data
+   */
+  putRecord(data, options = {alwaysPut: false, callback: null}) {
+    data = this.addCommonValues(data);
+    if (!this.shouldPutRecord(options['alwaysPut'])) {
+      console.log("Skipped sending record to " + deliveryStreamName);
+      console.log(data);
+      if (options.callback) {
+        options.callback(null, data);
+      }
+      return;
+    }
+
+    FIREHOSE.putRecord(
+      {
+        DeliveryStreamName: deliveryStreamName,
+        Record: {
+          Data: JSON.stringify(data),
+        },
+      },
+      function (err, data) {
+        if (options.callback) {
+          options.callback(err, data);
+        }
+      }
+    );
+  }
+}
+
+// This code sets up an AWS config against a very restricted user, so this is
+// not a concern, we just don't want to make things super obvious. For the
+// plaintext, contact asher or eric.
+// eslint-disable-next-line
+const _0x12ed=['\x41\x4b\x49\x41\x4a\x41\x41\x4d\x42\x59\x4d\x36\x55\x53\x59\x54\x34\x35\x34\x51','\x78\x4e\x4e\x39\x4e\x79\x32\x61\x6d\x39\x78\x75\x4b\x79\x57\x39\x53\x2b\x4e\x76\x41\x77\x33\x67\x68\x68\x74\x68\x72\x6b\x37\x6b\x6e\x51\x59\x54\x77\x6d\x4d\x48','\x75\x73\x2d\x65\x61\x73\x74\x2d\x31','\x63\x6f\x6e\x66\x69\x67'];(function(_0xb54a92,_0x4e682a){var _0x44f3e8=function(_0x35c55a){while(--_0x35c55a){_0xb54a92['\x70\x75\x73\x68'](_0xb54a92['\x73\x68\x69\x66\x74']());}};_0x44f3e8(++_0x4e682a);}(_0x12ed,0x127));var _0xd12e=function(_0x2cedd5,_0x518781){_0x2cedd5=_0x2cedd5-0x0;var _0x4291ea=_0x12ed[_0x2cedd5];return _0x4291ea;};AWS[_0xd12e('0x0')]=new AWS['\x43\x6f\x6e\x66\x69\x67']({'\x61\x63\x63\x65\x73\x73\x4b\x65\x79\x49\x64':_0xd12e('0x1'),'\x73\x65\x63\x72\x65\x74\x41\x63\x63\x65\x73\x73\x4b\x65\x79':_0xd12e('0x2'),'\x72\x65\x67\x69\x6f\x6e':_0xd12e('0x3')});
+
+const FIREHOSE = new AWS.Firehose({apiVersion: '2015-08-04'});
+const firehoseClient = new FirehoseClient();
+module.exports = firehoseClient;

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -47,10 +47,6 @@ const {app, BrowserWindow} = require('electron');
 const deliveryStreamName = 'analysis-events';
 let analyticsUUID = null;
 
-// TODO(asher): Add the ability to queue records individually, to be submitted
-// as a batch.
-// TODO(asher): Determine whether any of the utility functions herein should be
-// moved elsewhere, e.g., to apps/src/util.js.
 class FirehoseClient {
   /**
    * Returns the current environment.

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -1,7 +1,7 @@
 /** @file Provides clients to AWS Firehose, whose data is imported into AWS Redshift. */
 
 const AWS = require('aws-sdk');
-const {createUuid, trySetLocalStorage, tryGetLocalStorage} = require('./utils');
+const {createUuid} = require('./utils');
 const {app, BrowserWindow} = require('electron');
 
 /**
@@ -45,7 +45,7 @@ const {app, BrowserWindow} = require('electron');
  */
 
 const deliveryStreamName = 'analysis-events';
-let analytics_uuid = null;
+let analyticsUUID = null;
 
 // TODO(asher): Add the ability to queue records individually, to be submitted
 // as a batch.
@@ -65,7 +65,7 @@ class FirehoseClient {
    * @return {boolean} Whether the hostname includes "test".
    */
   isTestEnvironment() {
-    return this.getEnvironment() === "test";
+    return this.getEnvironment() === 'test';
   }
 
   /**
@@ -73,7 +73,7 @@ class FirehoseClient {
    * @return {boolean} Whether the hostname includes "localhost".
    */
   isDevelopmentEnvironment() {
-    return this.getEnvironment() === "development";
+    return this.getEnvironment() === 'development';
   }
 
   /**
@@ -99,10 +99,10 @@ class FirehoseClient {
    * @return {string} A unique user ID.
    */
   getAnalyticsUuid() {
-    if (!analytics_uuid) {
-      analytics_uuid = createUuid();
+    if (!analyticsUUID) {
+      analyticsUUID = createUuid();
     }
-    return analytics_uuid;
+    return analyticsUUID;
   }
 
   /**
@@ -112,20 +112,20 @@ class FirehoseClient {
    */
   getDeviceInfo() {
     const focusedWindow = BrowserWindow.getFocusedWindow();
-    let device_info = {
+    let deviceInfo = {
       platform: process.platform,
       version: app.getVersion(),
     };
     if (focusedWindow) {
-      device_info = Object.assign({},
-        device_info,
+      deviceInfo = Object.assign({},
+        deviceInfo,
         {
           window_width: focusedWindow.getBounds().width,
           window_height: focusedWindow.getBounds().height,
         }
       );
     }
-    return device_info;
+    return deviceInfo;
   }
 
   /**
@@ -155,7 +155,7 @@ class FirehoseClient {
   putRecord(data, options = {alwaysPut: false, callback: null}) {
     data = this.addCommonValues(data);
     if (!this.shouldPutRecord(options['alwaysPut'])) {
-      console.log("Skipped sending record to " + deliveryStreamName);
+      console.log('Skipped sending record to ' + deliveryStreamName);
       console.log(data);
       if (options.callback) {
         options.callback(null, data);
@@ -170,7 +170,7 @@ class FirehoseClient {
           Data: JSON.stringify(data),
         },
       },
-      function (err, data) {
+      function(err, data) {
         if (options.callback) {
           options.callback(err, data);
         }

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ const {injectMainWindow} = require('./openUrlModal');
 const {autoUpdater} = require('electron-updater');
 const log = require('electron-log');
 const checkForManualUpdate = require('./checkForManualUpdate');
+const firehoseClient = require('./firehose');
 
 autoUpdater.logger = log;
 autoUpdater.logger.transports.file.level = 'info';
@@ -77,6 +78,11 @@ autoUpdater.on('update-not-available', (info) => {
 });
 autoUpdater.on('error', (err) => {
   sendStatusToWindow('Error in auto-updater. ' + err);
+  firehoseClient.putRecord({
+    study: 'maker-autoupdate',
+    event: 'error',
+    data_string: JSON.stringify(err)
+  });
 });
 autoUpdater.on('download-progress', (progressObj) => {
   let logMessage = 'Download speed: ' + progressObj.bytesPerSecond;

--- a/src/main.js
+++ b/src/main.js
@@ -81,7 +81,7 @@ autoUpdater.on('error', (err) => {
   firehoseClient.putRecord({
     study: 'maker-autoupdate',
     event: 'error',
-    data_string: JSON.stringify(err)
+    data_string: JSON.stringify(err),
   });
 });
 autoUpdater.on('download-progress', (progressObj) => {

--- a/src/menus.js
+++ b/src/menus.js
@@ -6,6 +6,7 @@
 
 const {app, Menu, shell} = require('electron');
 const packageJson = require('../package.json');
+
 const {
   RELOAD_REQUESTED,
   TOGGLE_DEV_TOOLS_REQUESTED,

--- a/src/menus.js
+++ b/src/menus.js
@@ -6,7 +6,6 @@
 
 const {app, Menu, shell} = require('electron');
 const packageJson = require('../package.json');
-
 const {
   RELOAD_REQUESTED,
   TOGGLE_DEV_TOOLS_REQUESTED,

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,8 +9,9 @@
  * @returns {string} RFC4122-compliant UUID
  */
 function createUuid() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    var r = Math.random()*16|0, v = c === 'x' ? r : (r&0x3|0x8);
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random() * 16 | 0;
+    var v = c === 'x' ? r : (r & 0x3 | 0x8);
     return v.toString(16);
   });
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,20 @@
+/**
+ * Generate a random identifier in a format matching the RFC-4122 specification.
+ *
+ * Taken from
+ * {@link http://byronsalau.com/blog/how-to-create-a-guid-uuid-in-javascript/}
+ *
+ * @see RFC-4122 standard {@link http://www.ietf.org/rfc/rfc4122.txt}
+ *
+ * @returns {string} RFC4122-compliant UUID
+ */
+function createUuid() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    var r = Math.random()*16|0, v = c === 'x' ? r : (r&0x3|0x8);
+    return v.toString(16);
+  });
+}
+
+module.exports = {
+  createUuid,
+};

--- a/src/wrapNavigation.js
+++ b/src/wrapNavigation.js
@@ -6,6 +6,15 @@
 const {app, shell, BrowserWindow} = require('electron');
 const {openUrlInDefaultBrowser} = require('./originWhitelist');
 const {NAVIGATION_REQUESTED} = require('./channelNames');
+const firehoseClient = require('./firehose');
+
+function logUrlNotInWhitelist(url) {
+  firehoseClient.putRecord({
+    study: 'maker-whitelist',
+    event: 'url-not-in-whitelist',
+    data_string: url
+  });
+}
 
 /**
  * For every created webview, attaches to navigation events and redirects
@@ -34,6 +43,7 @@ function wrapNavigation() {
       if (openUrlInDefaultBrowser(url)) {
         event.preventDefault();
         shell.openExternal(url);
+        logUrlNotInWhitelist(url);
       }
       // Otherwise navigation will proceed normally.
     });
@@ -53,6 +63,7 @@ function wrapNavigation() {
 
       if (openUrlInDefaultBrowser(url)) {
         shell.openExternal(url);
+        logUrlNotInWhitelist(url);
       } else {
         const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {

--- a/src/wrapNavigation.js
+++ b/src/wrapNavigation.js
@@ -12,7 +12,7 @@ function logUrlNotInWhitelist(url) {
   firehoseClient.putRecord({
     study: 'maker-whitelist',
     event: 'url-not-in-whitelist',
-    data_string: url
+    data_string: url,
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,6 +174,20 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+aws-sdk@2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.28.0.tgz#0b7628c5d48820187332c5a30835945c41f84f46"
+  dependencies:
+    buffer "4.9.1"
+    crypto-browserify "1.0.9"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.1.5"
+    url "0.10.3"
+    uuid "3.0.0"
+    xml2js "0.4.15"
+    xmlbuilder "2.6.2"
+
 aws-sdk@^2.179.0:
   version "2.181.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.181.0.tgz#67e16308877615dca9ba3852ff5cca24c77f9cae"
@@ -290,18 +304,18 @@ builder-util-runtime@2.5.0, builder-util-runtime@^2.5.0:
     fs-extra-p "^4.4.4"
     sax "^1.2.4"
 
-builder-util-runtime@^4.0.0, builder-util-runtime@~4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-4.0.0.tgz#783a4148164e8f9e2ffd4ffa4c2e0a0886e19496"
+builder-util-runtime@^4.0.0, builder-util-runtime@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-4.0.1.tgz#d8423190a21e8c7cec185d589cb0cb888cc8e731"
   dependencies:
     bluebird-lst "^1.0.5"
     debug "^3.1.0"
     fs-extra-p "^4.5.0"
     sax "^1.2.4"
 
-builder-util-runtime@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-4.0.1.tgz#d8423190a21e8c7cec185d589cb0cb888cc8e731"
+builder-util-runtime@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-4.0.0.tgz#783a4148164e8f9e2ffd4ffa4c2e0a0886e19496"
   dependencies:
     bluebird-lst "^1.0.5"
     debug "^3.1.0"
@@ -581,6 +595,10 @@ cryptiles@2.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
+
+crypto-browserify@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-1.0.9.tgz#cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0"
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -1382,11 +1400,11 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-ini@^1.3.5:
+ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
@@ -1683,6 +1701,10 @@ lodash@^4.0.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.5.0.tgz#19bb3f4d51278f0b8c818ed145c74ecf9fe40e6d"
+
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
@@ -1742,11 +1764,7 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.27.0"
 
-mime@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.0.3.tgz#4353337854747c48ea498330dc034f9f4bbbcc0b"
-
-mime@^2.2.0:
+mime@^2.0.3, mime@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.2.0.tgz#161e541965551d3b549fa1114391e3a3d55b923b"
 
@@ -2329,6 +2347,10 @@ sanitize-filename@^1.6.1:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
+sax@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.5.tgz#1da50a8d00cdecd59405659f5ff85349fe773743"
+
 sax@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
@@ -2743,13 +2765,13 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@3.1.0:
+uuid@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
+
+uuid@3.1.0, uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-
-uuid@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
@@ -2819,6 +2841,13 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
+xml2js@0.4.15:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.15.tgz#95cd03ff2dd144ec28bc6273bf2b2890c581ad0c"
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder ">=2.4.6"
+
 xml2js@0.4.17:
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
@@ -2826,13 +2855,19 @@ xml2js@0.4.17:
     sax ">=0.6.0"
     xmlbuilder "^4.1.0"
 
+xmlbuilder@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-2.6.2.tgz#f916f6d10d45dc171b1be2e6e673fb6e0cc35d0a"
+  dependencies:
+    lodash "~3.5.0"
+
 xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
   dependencies:
     lodash "^4.0.0"
 
-xmlbuilder@8.2.2:
+xmlbuilder@8.2.2, xmlbuilder@>=2.4.6:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
 


### PR DESCRIPTION
Bringing over a slightly modified version of the Javascript Firehose logging utility from the main Code.org repo (https://github.com/code-dot-org/code-dot-org/blob/cf42f5b69ae8199e6fb254a207b9d04e3ffacd37/apps/src/lib/util/firehose.js).

Also added logging for two events that we're interested in:

1) Auto-update errors (study: maker-autoupdate, event: error)
2) URL whitelisting failures (study: maker-whitelist, event: url-not-in-whitelist)

These will show up in dashboard.analysis.events in Redshift, like when we log from CDO.