### PR TITLE
Ignore all .p12 files in project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config/ci.json
 config/release.json
 dist
 node_modules
+*.p12


### PR DESCRIPTION
When building via Docker, it can be useful to have Windows code signing files in the project directory, so we should ignore them in git.