### PR TITLE
Fix whitelist logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
     "win": "build --win --config ./config/_common.json",
     "linux": "build --linux --config ./config/_common.json",
     "prerelease": "yarn generate-config",
-    "release": "build --win --x64 --ia32 --mac --linux --config ./config/release.json --publish always"
+    "release": "NODE_ENV=production build --win --x64 --ia32 --mac --linux --config ./config/release.json --publish always"
   },
   "dependencies": {
     "electron-log": "^1.3.0",
     "electron-updater": "^2.15.0",
     "lodash": "^4.17.4",
     "serialport": "6.0.4",
-    "aws-sdk": "2.28.0"
+    "aws-sdk": "2.28.0",
+    "electron-is-dev": "^0.3.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -4,6 +4,7 @@ const AWS = require('aws-sdk');
 const {createUuid} = require('./utils');
 const {app, BrowserWindow} = require('electron');
 const log = require('electron-log');
+const isDev = require('electron-is-dev');
 
 /**
  * Adapted from https://github.com/code-dot-org/code-dot-org/blob/54ab514aafdd2651e6232b1b51c8281b3a93a851/apps/src/lib/util/firehose.js
@@ -54,7 +55,7 @@ class FirehoseClient {
    * @return {string} The current environment, e.g., "staging" or "production".
    */
   getEnvironment() {
-    return process.env.NODE_ENV;
+    return isDev ? 'development' : 'production';
   }
 
   /**

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -3,6 +3,7 @@
 const AWS = require('aws-sdk');
 const {createUuid} = require('./utils');
 const {app, BrowserWindow} = require('electron');
+const log = require('electron-log');
 
 /**
  * Adapted from https://github.com/code-dot-org/code-dot-org/blob/54ab514aafdd2651e6232b1b51c8281b3a93a851/apps/src/lib/util/firehose.js
@@ -151,14 +152,14 @@ class FirehoseClient {
   putRecord(data, options = {alwaysPut: false, callback: null}) {
     data = this.addCommonValues(data);
     if (!this.shouldPutRecord(options['alwaysPut'])) {
-      console.log('Skipped sending record to ' + deliveryStreamName);
-      console.log(data);
+      log.info('Skipped sending record to ' + deliveryStreamName);
+      log.info(data);
       if (options.callback) {
         options.callback(null, data);
       }
       return;
     }
-
+    log.info('Putting record: ' + JSON.stringify(data));
     FIREHOSE.putRecord(
       {
         DeliveryStreamName: deliveryStreamName,

--- a/src/openUrlModal/index.js
+++ b/src/openUrlModal/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const url = require('url');
 const {REQUEST_NAVIGATION, NAVIGATION_REQUESTED} = require('../channelNames');
 const {openUrlInDefaultBrowser} = require('../originWhitelist');
+const firehoseClient = require('../firehose');
 
 let _mainWindow;
 let _isOpen = false;
@@ -49,8 +50,12 @@ function handleNavigation(_, url) {
   if (!_mainWindow) {
     throw new Error('A reference to the main window has not been established.');
   }
-
   if (openUrlInDefaultBrowser(url)) {
+    firehoseClient.putRecord({
+      study: 'maker-whitelist',
+      event: 'url-not-in-whitelist',
+      data_string: url,
+    });
     shell.openExternal(url);
   } else {
     _mainWindow.webContents.send(NAVIGATION_REQUESTED, url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2855,7 +2855,7 @@ xml2js@0.4.17:
     sax ">=0.6.0"
     xmlbuilder "^4.1.0"
 
-xmlbuilder@2.6.2:
+xmlbuilder@2.6.2, xmlbuilder@>=2.4.6:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-2.6.2.tgz#f916f6d10d45dc171b1be2e6e673fb6e0cc35d0a"
   dependencies:
@@ -2867,7 +2867,7 @@ xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
   dependencies:
     lodash "^4.0.0"
 
-xmlbuilder@8.2.2, xmlbuilder@>=2.4.6:
+xmlbuilder@8.2.2:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
 


### PR DESCRIPTION
Logging events were not properly getting through to Redshift, and after some investigation it turned out that this was because NODE_ENV is not set when running a built version of the app (nor should it be). The right way to check environment is to use the `electron-is-dev` library.

In the meantime, I also noticed that I had missed instrumenting one of the whitelist checks, so am updating that as well.

This PR also switches a few logging statements from using `console.log` to the proper electron logger, which reliably logs in any environment.