### PR TITLE
Never kick navigation to default browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code.org Maker App [![GitHub release](https://img.shields.io/github/release/code-dot-org/browser.svg)](https://github.com/code-dot-org/browser/releases/latest) [![Build Status](https://travis-ci.org/code-dot-org/browser.svg?branch=master)](https://travis-ci.org/code-dot-org/browser) [![Build status](https://ci.appveyor.com/api/projects/status/s05fruj5b0hibar6?svg=true)](https://ci.appveyor.com/project/islemaster/browser)
 
-Simple browser exposing native node-serialport to web-based tools on whitelisted Code.org domains.
+Simple browser exposing native node-serialport to web-based tools on allowlisted Code.org domains.
 
 ## Installation
 

--- a/src/openUrlModal/index.js
+++ b/src/openUrlModal/index.js
@@ -3,7 +3,7 @@ const {BrowserWindow, ipcMain, shell} = require('electron');
 const path = require('path');
 const url = require('url');
 const {REQUEST_NAVIGATION, NAVIGATION_REQUESTED} = require('../channelNames');
-const {openUrlInDefaultBrowser} = require('../originWhitelist');
+const {openUrlInDefaultBrowser} = require('../originAllowlist');
 const firehoseClient = require('../firehose');
 
 let _mainWindow;

--- a/src/openUrlModal/index.js
+++ b/src/openUrlModal/index.js
@@ -1,10 +1,8 @@
 /** @file Main process setup for "Open URL..." dialog */
-const {BrowserWindow, ipcMain, shell} = require('electron');
+const {BrowserWindow, ipcMain} = require('electron');
 const path = require('path');
 const url = require('url');
 const {REQUEST_NAVIGATION, NAVIGATION_REQUESTED} = require('../channelNames');
-const {openUrlInDefaultBrowser} = require('../originAllowlist');
-const firehoseClient = require('../firehose');
 
 let _mainWindow;
 let _isOpen = false;
@@ -50,16 +48,7 @@ function handleNavigation(_, url) {
   if (!_mainWindow) {
     throw new Error('A reference to the main window has not been established.');
   }
-  if (openUrlInDefaultBrowser(url)) {
-    firehoseClient.putRecord({
-      study: 'maker-whitelist',
-      event: 'url-not-in-whitelist',
-      data_string: url,
-    });
-    shell.openExternal(url);
-  } else {
-    _mainWindow.webContents.send(NAVIGATION_REQUESTED, url);
-  }
+  _mainWindow.webContents.send(NAVIGATION_REQUESTED, url);
 }
 
 module.exports = {

--- a/src/openUrlModal/view.js
+++ b/src/openUrlModal/view.js
@@ -2,7 +2,7 @@
 const {ipcRenderer} = require('electron');
 const {URL} = require('url');
 const {REQUEST_NAVIGATION} = require('../channelNames');
-const {openUrlInDefaultBrowser} = require('../originWhitelist');
+const {openUrlInDefaultBrowser} = require('../originAllowlist');
 
 function onLoad() {
   document.removeEventListener('DOMContentLoaded', onLoad);

--- a/src/openUrlModal/view.js
+++ b/src/openUrlModal/view.js
@@ -2,7 +2,6 @@
 const {ipcRenderer} = require('electron');
 const {URL} = require('url');
 const {REQUEST_NAVIGATION} = require('../channelNames');
-const {openUrlInDefaultBrowser} = require('../originAllowlist');
 
 function onLoad() {
   document.removeEventListener('DOMContentLoaded', onLoad);
@@ -29,11 +28,7 @@ function onLoad() {
       // @see https://nodejs.org/api/url.html#url_constructor_new_url_input_base
       new URL(urlInput.value); // eslint-disable-line no-new
       // If we get this far we have a valid URL
-      if (openUrlInDefaultBrowser(urlInput.value)) {
-        errorFeedback.textContent = 'URL will open in system default browser.';
-      } else {
-        errorFeedback.textContent = '';
-      }
+      errorFeedback.textContent = '';
       goButton.disabled = false;
       return true;
     } catch (e) {

--- a/src/originAllowlist.js
+++ b/src/originAllowlist.js
@@ -6,7 +6,6 @@
  *
  * Process: Main or Renderer
  */
-const {URL} = require('url');
 
 // Match origins:
 // https://studio.code.org                          Production
@@ -30,65 +29,15 @@ const INTERNAL_BLOCKLIST = [
 ];
 
 /**
- * Limited set of non-Code.org pages we will load within Code.org Maker App,
- * mostly for things like OAuth or other integrations with external services.
- * We won't inject native APIs to these sites even though they load within the
- * app.
- * @type {Array.<RegExp>}
- */
-const EXTERNAL_ALLOWLIST = [
-  // Google OAuth
-  /\/\/accounts\.google\.com(?:$|\/)/i,
-  /\/\/www\.google\.com\/accounts\//i,
-  // Google GSuite prefix sometimes used for district-specific redirects.
-  /\/\/www\.google\.com\/a\//i,
-  // Facebook OAuth
-  /\/\/www\.facebook\.com\/v[^/]+\/dialog\/oauth/i,
-  /\/\/www\.facebook\.com\/logout/i,
-  // Microsoft OAuths
-  /\/\/login\.live\.com(?:$|\/)/i,
-  // Clever Auth
-  /\/\/clever.com\/(?:in|login|oauth)(?:$|\/)/i,
-  // School- and District-specific portals
-  /\/\/sso.pcsd1.org(?:$|\/)/i,
-  /\/\/[.\w]*cps\.edu\//i,
-];
-
-/**
- * @param {string} url
- * @returns {boolean} whether the url should be opened in the system default
- *   browser.
- */
-function openUrlInDefaultBrowser(url) {
-  const origin = new URL(url).origin;
-  return !(originIsOnInternalAllowlist(origin) || urlIsOnExternalAllowlist(url));
-}
-
-/**
  * @param {string} origin
  * @returns {boolean} whether we're allowed to inject a native API into a page
  *   loaded from the given origin.
  */
 function mayInjectNativeApi(origin) {
-  return originIsOnInternalAllowlist(origin);
-}
-
-function originIsOnInternalAllowlist(origin) {
   return CODE_ORG_URL.test(origin) &&
     !INTERNAL_BLOCKLIST.some(site => site.test(origin));
 }
 
-function urlIsOnExternalAllowlist(url) {
-  return EXTERNAL_ALLOWLIST.some(site => site.test(url));
-}
-
-function isCodeOrgUrl(url) {
-  const origin = new URL(url).origin;
-  return CODE_ORG_URL.test(origin);
-}
-
 module.exports = {
-  isCodeOrgUrl,
-  openUrlInDefaultBrowser,
   mayInjectNativeApi,
 };

--- a/src/originAllowlist.js
+++ b/src/originAllowlist.js
@@ -1,8 +1,6 @@
 /**
- * @file Defines the allowlist of sites that are not allowed to load in the
- * Code.org Maker App and have our native Maker API (including Serialport)
- * injected.  Sites not on this allowlist will be loaded in the system's
- * native browser, not in Code.org Maker App.
+ * @file Defines the allowlist of sites that can have our native
+ * Maker API (including Serialport) injected.
  *
  * Process: Main or Renderer
  */
@@ -15,8 +13,7 @@
 const CODE_ORG_URL = /^https?:\/\/(?:[\w\d-]+\.)?(?:cdn-)?code\.org(?::\d+)?$/i;
 
 /**
- * Navigation to urls matching any of the given origins will open the page in
- * the system default browser, instead of within Code.org Maker App, even
+ * These urls shouldn't have the Maker API injected, even
  * if the origin falls within our general Code.org origin allowlist.
  * @type {Array.<RegExp>}
  */

--- a/src/originAllowlist.js
+++ b/src/originAllowlist.js
@@ -1,7 +1,7 @@
 /**
- * @file Defines the whitelist of sites that are allowed to load in the
+ * @file Defines the allowlist of sites that are not allowed to load in the
  * Code.org Maker App and have our native Maker API (including Serialport)
- * injected.  Sites not on this whitelist will be loaded in the system's
+ * injected.  Sites not on this allowlist will be loaded in the system's
  * native browser, not in Code.org Maker App.
  *
  * Process: Main or Renderer
@@ -18,10 +18,10 @@ const CODE_ORG_URL = /^https?:\/\/(?:[\w\d-]+\.)?(?:cdn-)?code\.org(?::\d+)?$/i;
 /**
  * Navigation to urls matching any of the given origins will open the page in
  * the system default browser, instead of within Code.org Maker App, even
- * if the origin falls within our general Code.org origin whitelist.
+ * if the origin falls within our general Code.org origin allowlist.
  * @type {Array.<RegExp>}
  */
-const INTERNAL_BLACKLIST = [
+const INTERNAL_BLOCKLIST = [
   /curriculum\.code\.org$/i,
   /docs\.code\.org$/i,
   /forum\.code\.org$/i,
@@ -36,7 +36,7 @@ const INTERNAL_BLACKLIST = [
  * app.
  * @type {Array.<RegExp>}
  */
-const EXTERNAL_WHITELIST = [
+const EXTERNAL_ALLOWLIST = [
   // Google OAuth
   /\/\/accounts\.google\.com(?:$|\/)/i,
   /\/\/www\.google\.com\/accounts\//i,
@@ -61,7 +61,7 @@ const EXTERNAL_WHITELIST = [
  */
 function openUrlInDefaultBrowser(url) {
   const origin = new URL(url).origin;
-  return !(originIsOnInternalWhitelist(origin) || urlIsOnExternalWhitelist(url));
+  return !(originIsOnInternalAllowlist(origin) || urlIsOnExternalAllowlist(url));
 }
 
 /**
@@ -70,16 +70,16 @@ function openUrlInDefaultBrowser(url) {
  *   loaded from the given origin.
  */
 function mayInjectNativeApi(origin) {
-  return originIsOnInternalWhitelist(origin);
+  return originIsOnInternalAllowlist(origin);
 }
 
-function originIsOnInternalWhitelist(origin) {
+function originIsOnInternalAllowlist(origin) {
   return CODE_ORG_URL.test(origin) &&
-    !INTERNAL_BLACKLIST.some(site => site.test(origin));
+    !INTERNAL_BLOCKLIST.some(site => site.test(origin));
 }
 
-function urlIsOnExternalWhitelist(url) {
-  return EXTERNAL_WHITELIST.some(site => site.test(url));
+function urlIsOnExternalAllowlist(url) {
+  return EXTERNAL_ALLOWLIST.some(site => site.test(url));
 }
 
 function isCodeOrgUrl(url) {

--- a/src/preload.js
+++ b/src/preload.js
@@ -10,7 +10,7 @@
 
 const SerialPort = require('serialport');
 const packageJson = require('../package.json');
-const {mayInjectNativeApi} = require('./originWhitelist');
+const {mayInjectNativeApi} = require('./originAllowlist');
 
 function init() {
   if (!mayInjectNativeApi(document.location.origin)) {

--- a/src/wrapNavigation.js
+++ b/src/wrapNavigation.js
@@ -3,18 +3,8 @@
  *
  * Process: Main
  */
-const {app, shell, BrowserWindow} = require('electron');
-const {openUrlInDefaultBrowser, isCodeOrgUrl} = require('./originAllowlist');
+const {app, BrowserWindow} = require('electron');
 const {NAVIGATION_REQUESTED} = require('./channelNames');
-const firehoseClient = require('./firehose');
-
-function logUrlNotInAllowlist(url) {
-  firehoseClient.putRecord({
-    study: 'maker-whitelist',
-    event: 'url-not-in-whitelist',
-    data_string: url,
-  });
-}
 
 /**
  * For every created webview, attaches to navigation events and redirects
@@ -24,18 +14,6 @@ function logUrlNotInAllowlist(url) {
  * existing view if they're allowlisted, or open in the system browser if not.
  */
 function wrapNavigation() {
-  let inOauthFlow = false;
-
-  // Checks whether navigating to a URL either begins or terminates
-  // an oauth flow, and sets the state variable accordingly
-  function checkForOauthFlow(url) {
-    if (url.includes('studio.code.org') && url.includes('/users/auth/')) {
-      inOauthFlow = true;
-    } else if (inOauthFlow && isCodeOrgUrl(url)) {
-      inOauthFlow = false;
-    }
-  }
-
   // We apply this behavior to all created webviews, whenever they get created,
   // because we have to handle this event on the main thread.
   // This is the preferred approach to capturing and preventing navigation
@@ -46,22 +24,6 @@ function wrapNavigation() {
     if (webContents.getType() !== 'webview') {
       return;
     }
-
-    // Capture requests to navigate within the webview and open links in the
-    // system default browser instead if they are outside the Code.org Maker App
-    // walled garden of allowlisted origins.
-    // @see https://electron.atom.io/docs/api/web-contents/#event-will-navigate
-    webContents.on('will-navigate', (event, url) => {
-      // Disable allowlist check if we're in the oauth flow
-      checkForOauthFlow(url);
-
-      if (!inOauthFlow && openUrlInDefaultBrowser(url)) {
-        event.preventDefault();
-        shell.openExternal(url);
-        logUrlNotInAllowlist(url);
-      }
-      // Otherwise navigation will proceed normally.
-    });
 
     // Capture requests to open a new tab or window, triggered by calls to
     // `window.open` or links with `target="_blank"`, and handle them
@@ -75,19 +37,11 @@ function wrapNavigation() {
       // call this method in the wrong context.
       // @see https://github.com/electron/electron/issues/1963
       event.preventDefault();
-
-      checkForOauthFlow(url);
-
-      if (!inOauthFlow && openUrlInDefaultBrowser(url)) {
-        shell.openExternal(url);
-        logUrlNotInAllowlist(url);
+      const focusedWindow = BrowserWindow.getFocusedWindow();
+      if (focusedWindow) {
+        focusedWindow.webContents.send(NAVIGATION_REQUESTED, url);
       } else {
-        const focusedWindow = BrowserWindow.getFocusedWindow();
-        if (focusedWindow) {
-          focusedWindow.webContents.send(NAVIGATION_REQUESTED, url);
-        } else {
-          console.warn('Unable to navigate, there is no focused window.');
-        }
+        console.warn('Unable to navigate, there is no focused window.');
       }
     });
   });

--- a/src/wrapNavigation.js
+++ b/src/wrapNavigation.js
@@ -7,11 +7,9 @@ const {app, BrowserWindow} = require('electron');
 const {NAVIGATION_REQUESTED} = require('./channelNames');
 
 /**
- * For every created webview, attaches to navigation events and redirects
- * attempted navigation to a non-allowlisted site to the system's default
- * browser instead of navigating within the webview itself.
- * Also makes links that would normally open in a new tab/window open in the
- * existing view if they're allowlisted, or open in the system browser if not.
+ * For every created webview, attaches to navigation events and makes
+ * links that would normally open in a new tab/window open in the
+ * existing view.
  */
 function wrapNavigation() {
   // We apply this behavior to all created webviews, whenever they get created,

--- a/test/originAllowlistTest.js
+++ b/test/originAllowlistTest.js
@@ -4,9 +4,9 @@ const {URL} = require('url');
 const {
   openUrlInDefaultBrowser,
   mayInjectNativeApi,
-} = require('../src/originWhitelist');
+} = require('../src/originAllowlist');
 
-const WHITELISTED_INTERNAL_PAGES = [
+const ALLOWLISTED_INTERNAL_PAGES = [
   // Production
   'https://code.org',
   'https://studio.code.org',
@@ -21,7 +21,7 @@ const WHITELISTED_INTERNAL_PAGES = [
   'http://localhost-studio.code.org:3000',
 ];
 
-const WHITELISTED_EXTERNAL_PAGES = [
+const ALLOWLISTED_EXTERNAL_PAGES = [
   // Google OAuth
   'https://accounts.google.com',
   'https://accounts.google.com/signin/oauth',
@@ -54,7 +54,7 @@ const WHITELISTED_EXTERNAL_PAGES = [
   'https://portal.id.cps.edu/idp/profile/SAML2/Redirect/SSO',
 ];
 
-const BLACKLISTED_PAGES = [
+const BLOCKLISTED_PAGES = [
   'https://curriculum.code.org',
   'https://docs.code.org',
   'https://forum.code.org',
@@ -76,7 +76,7 @@ function originFromUrl(url) {
 describe('openUrlInDefaultBrowser', () => {
   // These should load in the system default browser
   [
-    ...BLACKLISTED_PAGES,
+    ...BLOCKLISTED_PAGES,
   ].forEach((url) => {
     it(`true for ${url}`, () => {
       expect(openUrlInDefaultBrowser(url)).to.be.true;
@@ -85,8 +85,8 @@ describe('openUrlInDefaultBrowser', () => {
 
   // These should load within Code.org Maker App
   [
-    ...WHITELISTED_INTERNAL_PAGES,
-    ...WHITELISTED_EXTERNAL_PAGES,
+    ...ALLOWLISTED_INTERNAL_PAGES,
+    ...ALLOWLISTED_EXTERNAL_PAGES,
   ].forEach((url) => {
     it(`false for ${url}`, () => {
       expect(openUrlInDefaultBrowser(url)).to.be.false;
@@ -98,7 +98,7 @@ describe('mayInjectNativeApi', () => {
   // These should get the native APIs injected into the page
   _.uniq(
     [
-      ...WHITELISTED_INTERNAL_PAGES,
+      ...ALLOWLISTED_INTERNAL_PAGES,
     ].map(originFromUrl)
   ).forEach((origin) => {
     it(`allows ${origin}`, () => {
@@ -109,8 +109,8 @@ describe('mayInjectNativeApi', () => {
   // These should never get native APIs injected into the page
   _.uniq(
     [
-      ...WHITELISTED_EXTERNAL_PAGES,
-      ...BLACKLISTED_PAGES,
+      ...ALLOWLISTED_EXTERNAL_PAGES,
+      ...BLOCKLISTED_PAGES,
     ].map(originFromUrl)
   ).forEach((origin) => {
     it(`blocks ${origin}`, () => {

--- a/test/originAllowlistTest.js
+++ b/test/originAllowlistTest.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const { expect } = require('chai');
 const {URL} = require('url');
 const {
-  openUrlInDefaultBrowser,
   mayInjectNativeApi,
 } = require('../src/originAllowlist');
 
@@ -72,27 +71,6 @@ const BLOCKLISTED_PAGES = [
 function originFromUrl(url) {
   return new URL(url).origin;
 }
-
-describe('openUrlInDefaultBrowser', () => {
-  // These should load in the system default browser
-  [
-    ...BLOCKLISTED_PAGES,
-  ].forEach((url) => {
-    it(`true for ${url}`, () => {
-      expect(openUrlInDefaultBrowser(url)).to.be.true;
-    });
-  });
-
-  // These should load within Code.org Maker App
-  [
-    ...ALLOWLISTED_INTERNAL_PAGES,
-    ...ALLOWLISTED_EXTERNAL_PAGES,
-  ].forEach((url) => {
-    it(`false for ${url}`, () => {
-      expect(openUrlInDefaultBrowser(url)).to.be.false;
-    });
-  });
-});
 
 describe('mayInjectNativeApi', () => {
   // These should get the native APIs injected into the page


### PR DESCRIPTION
([STAR-186](https://codedotorg.atlassian.net/browse/STAR-186)) We've had a spike of helpdesk tickets from teachers having trouble with SSO in the Code.org Maker App, specifically caused by this feature that kicks the user to their default browser when navigating to a URL not on our allow-list.  Per [this Slack discussion](https://codedotorg.slack.com/archives/C0T0EGE8L/p1552949091009600) we don't treat this as a selling point for the app, and are okay with removing this "security" feature to solve the widespread sign-in issues.

Note, we still use the allowlist to decide when to inject our custom Maker API (which includes node-serialport) into the page, so that we're not allowing arbitrary pages visited through the Maker App to interact with the user's serialport.

With these changes I've launched the app locally, tested the "Go to URL..." feature, navigated through several Maker Toolkit lessons in CS Discoveries Unit 6 with a board plugged in and confirmed successful board connection, and checked that I can now navigate to urls like https://google.com/.

After merging this change I'll perform a minor version bump and publish a release per the instructions in the README - which may be somewhat out-of-date, so I'll update those if needed.