### PR TITLE
Add Google OAuth Button

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -79,6 +79,11 @@ window.onload = function() {
     navigateTo(CLEVER_LOGIN_URL);
   };
 
+  document.querySelector('#google-login').onclick = function() {
+    // Opens link in default browser
+    require('electron').shell.openExternal('https://studio.code.org/users/sign_in');
+  };
+
   webview.addEventListener('close', handleExit);
   webview.addEventListener('did-start-loading', handleLoadStart);
   webview.addEventListener('did-stop-loading', handleLoadStop);

--- a/src/browser.js
+++ b/src/browser.js
@@ -19,6 +19,8 @@ const {
   MAKER_SETUP_URL,
   CLEVER_LOGIN_URL,
   GOOGLE_LOGIN_URL,
+  MAKER_LOGIN_URL,
+  SIGN_IN_URL,
 } = require('./defaults');
 
 window.onresize = doLayout;
@@ -82,7 +84,8 @@ window.onload = function() {
 
   document.querySelector('#google-login').onclick = function() {
     // Opens link in default browser
-    require('electron').shell.openExternal(GOOGLE_LOGIN_URL);
+    require('electron').shell.openExternal(SIGN_IN_URL + '?user_return_to=/maker/display_code&maker=true');
+    navigateTo(MAKER_LOGIN_URL);
   };
 
   webview.addEventListener('close', handleExit);

--- a/src/browser.js
+++ b/src/browser.js
@@ -18,6 +18,7 @@ const {
   HOME_URL,
   MAKER_SETUP_URL,
   CLEVER_LOGIN_URL,
+  GOOGLE_LOGIN_URL,
 } = require('./defaults');
 
 window.onresize = doLayout;
@@ -81,7 +82,7 @@ window.onload = function() {
 
   document.querySelector('#google-login').onclick = function() {
     // Opens link in default browser
-    require('electron').shell.openExternal('https://studio.code.org/users/sign_in');
+    require('electron').shell.openExternal(GOOGLE_LOGIN_URL);
   };
 
   webview.addEventListener('close', handleExit);

--- a/src/browser.js
+++ b/src/browser.js
@@ -18,7 +18,6 @@ const {
   HOME_URL,
   MAKER_SETUP_URL,
   CLEVER_LOGIN_URL,
-  GOOGLE_LOGIN_URL,
   MAKER_LOGIN_URL,
   SIGN_IN_URL,
 } = require('./defaults');
@@ -84,7 +83,7 @@ window.onload = function() {
 
   document.querySelector('#google-login').onclick = function() {
     // Opens link in default browser
-    require('electron').shell.openExternal(SIGN_IN_URL + '?user_return_to=/maker/display_code&maker=true');
+    require('electron').shell.openExternal(SIGN_IN_URL + '?user_return_to=/maker/display_google_oauth_code&maker=true');
     navigateTo(MAKER_LOGIN_URL);
   };
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -11,6 +11,6 @@ module.exports = {
   MAKER_SETUP_URL: DASHBOARD_HOST + '/maker/setup',
   CLEVER_LOGIN_URL: 'https://clever.com/login',
   GOOGLE_LOGIN_URL: DASHBOARD_HOST + '/users/auth/google_oauth2',
-  MAKER_LOGIN_URL: DASHBOARD_HOST + '/maker/login_code',
+  MAKER_LOGIN_URL: DASHBOARD_HOST + '/maker/google_oauth_login_code',
   SIGN_IN_URL: DASHBOARD_HOST + '/users/sign_in',
 };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -10,4 +10,5 @@ module.exports = {
   HOME_URL: DASHBOARD_HOST + '/maker/home',
   MAKER_SETUP_URL: DASHBOARD_HOST + '/maker/setup',
   CLEVER_LOGIN_URL: 'https://clever.com/login',
+  GOOGLE_LOGIN_URL: DASHBOARD_HOST + '/users/auth/google_oauth2'
 };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -11,4 +11,6 @@ module.exports = {
   MAKER_SETUP_URL: DASHBOARD_HOST + '/maker/setup',
   CLEVER_LOGIN_URL: 'https://clever.com/login',
   GOOGLE_LOGIN_URL: DASHBOARD_HOST + '/users/auth/google_oauth2',
+  MAKER_LOGIN_URL: DASHBOARD_HOST + '/maker/login_code',
+  SIGN_IN_URL: DASHBOARD_HOST + '/users/sign_in',
 };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -10,5 +10,5 @@ module.exports = {
   HOME_URL: DASHBOARD_HOST + '/maker/home',
   MAKER_SETUP_URL: DASHBOARD_HOST + '/maker/setup',
   CLEVER_LOGIN_URL: 'https://clever.com/login',
-  GOOGLE_LOGIN_URL: DASHBOARD_HOST + '/users/auth/google_oauth2'
+  GOOGLE_LOGIN_URL: DASHBOARD_HOST + '/users/auth/google_oauth2',
 };

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,7 @@
     <button id="reload" title="Reload">&#10227;</button>
     <button id="setup" title="Setup">&#x2699;</button>
     <button id="clever-login" title="Log in with Clever">Log in with Clever</button>
+    <button id="google-login" title="Log in with Google">Log in with Google</button>
   </div>
 
   <webview preload="./preload.js" partition="persist:codeorg-maker-app"></webview>


### PR DESCRIPTION
Part of solving the Google OAuth issue in Maker Toolkit.

Adds button to maker. Opens page in default browser. Opens page in maker browser.

Spec: https://docs.google.com/document/d/1Vd8btlBuTN90Qu57EYpKxb90z7ApuAd6oC2z0JDAKYg/edit