### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-dot-org-browser",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "A browser with Code.org-specific extensions, built with Electron",
   "homepage": "https://code.org",
   "repository": "https://github.com/code-dot-org/browser",


### PR DESCRIPTION
Manually bump version to 1.1.7, which is now the latest release in S3