### PR TITLE
Update Electron to version that support ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "electron": "^1.8.8",
+    "electron": "^2.0.0",
     "electron-builder": "^19.43.3",
     "electron-publisher-s3": "^19.53.4",
     "eslint": "^4.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,10 +1193,10 @@ electron-updater@^2.15.0:
     semver "^5.4.1"
     source-map-support "^0.5.0"
 
-electron@^1.8.8:
-  version "1.8.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.8.tgz#a90cddb075291f49576993e6f5c8bb4439301cae"
-  integrity sha512-1f9zJehcTTGjrkb06o6ds+gsRq6SYhZJyxOk6zIWjRH8hVy03y/RzUDELzNas71f5vcvXmfGVvyjeEsadDI8tg==
+electron@^2.0.0:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.18.tgz#52f1b248c3cc013b5a870094de3b6ba5de313a0f"
+  integrity sha512-PQRHtFvLxHdJzMMIwTddUtkS+Te/fZIs+PHO+zPmTUTBE76V3Od3WRGzMQwiJHxN679licmCKhJpMyxZfDEVWQ==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
Reports on Zendesk that classes on Linux in the Maker app were seeing this error:
![Screenshot from 2020-03-17 16-29-26](https://user-images.githubusercontent.com/2959170/76910900-837d3900-686c-11ea-85d5-6f7d2a9a4b56.png)

Traced it back to not being able to load the preload file because node was throwing an error that the serialport was using ES6, but they were using a version of Node that didn't support that. Discovered that the version of Electron we were using was on Node v.8.2.1. Updated the version of Electron from 1.8.8 to 2.0.0 (most recent is 8.x.x.) and this used a more recent version of node that support ES6.

For those not on Linux, please pull and test that you can run a project with the board!