### PR TITLE
change sign in url to go directly to the confirm login page

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -83,7 +83,7 @@ window.onload = function() {
 
   document.querySelector('#google-login').onclick = function() {
     // Opens link in default browser
-    require('electron').shell.openExternal(SIGN_IN_URL + '?user_return_to=/maker/display_google_oauth_code&maker=true');
+    require('electron').shell.openExternal(SIGN_IN_URL + '?user_return_to=/maker/display_google_oauth_code');
     navigateTo(MAKER_LOGIN_URL);
   };
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -12,5 +12,5 @@ module.exports = {
   CLEVER_LOGIN_URL: 'https://clever.com/login',
   GOOGLE_LOGIN_URL: DASHBOARD_HOST + '/users/auth/google_oauth2',
   MAKER_LOGIN_URL: DASHBOARD_HOST + '/maker/google_oauth_login_code',
-  SIGN_IN_URL: DASHBOARD_HOST + '/users/sign_in',
+  SIGN_IN_URL: DASHBOARD_HOST + '/maker/google_oauth_confirm_login',
 };


### PR DESCRIPTION
NOTE: this should not be merged until the [related PR in Code Studio](https://github.com/code-dot-org/code-dot-org/pull/38245) is deployed.
A few changes here:
1. When a user was already logged in, they were seeing an error instead of the "magic code" to paste into Maker App. This takes them directly to the code page if they're already logged in. 
2. If a user tries to log in without a google authentication option, show them a more useful message (final wording still in progress). This is actually handled in the [related PR](https://github.com/code-dot-org/code-dot-org/pull/38245) in Code Studio

Here's a video for when a user is not logged in and uses a valid google auth option: https://drive.google.com/file/d/1_fvrYv2oMNnOcluvxi2LFgRiSGbIGlJW/view?usp=sharing 
Here's a video for when a user is not logged in and uses a non google auth option: https://drive.google.com/file/d/1SAux-C79c6dOOyJu_IxR2nL3v60vgZhQ/view?usp=sharing
If the user is already logged in, it will skip directly to that last page (with either the code or the error message depending on the existence of a google authentication option)



<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1349?atlOrigin=eyJpIjoiNmM1ODMxY2RkNTVjNDYzMWE0ZjY0OTk0YzVlNWFiOWIiLCJwIjoiaiJ9)
- [related PR on Code Studio to improve error handling and streamline the login for already logged in users](https://github.com/code-dot-org/code-dot-org/pull/38245)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
