### PR TITLE
Remove AvrGirl

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
-    "avrgirl-arduino": "^4.2.1",
     "aws-sdk": "2.28.0",
     "blueimp-md5": "^2.11.0",
     "electron-is-dev": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "aws-sdk": "2.28.0",
-    "blueimp-md5": "^2.11.0",
     "electron-is-dev": "^0.3.0",
     "electron-log": "^1.3.0",
     "electron-updater": "^2.15.0",

--- a/src/preload.js
+++ b/src/preload.js
@@ -11,7 +11,6 @@
 const SerialPort = require('serialport');
 const packageJson = require('../package.json');
 const {mayInjectNativeApi} = require('./originAllowlist');
-const Avrgirl = require('avrgirl-arduino');
 const md5 = require('blueimp-md5');
 
 function init() {
@@ -23,41 +22,7 @@ function init() {
   window.SerialPort = SerialPort;
   window.MakerBridge = {
     getVersion,
-    flashBoardFirmware,
   };
-}
-
-/**
- * Flash firmware of board with contents of specified hex file.
- * @param {Object} flashInfo, info to flash board
- * @param {String} flashInfo.boardName, name of board from Avrgirl options
- * @param {String} flashInfo.hexPath, path to hex file to flash to board
- * @param {String} flashInfo.checksum, checksum to verify valid hex download
- * @return {Promise}
- */
-function flashBoardFirmware(flashInfo) {
-  return new Promise((resolve, reject) => {
-    let avrgirl = new Avrgirl({board: flashInfo.boardName});
-    window.fetch(flashInfo.hexPath)
-      .then(function(response) {
-        // Hard coded checksum value to verify valid hex download
-        if (md5(response) === flashInfo.checksum) {
-          response.arrayBuffer().then(function(body) {
-            // Pass the response buffer to flash function to avoid filesystem error
-            avrgirl.flash(Buffer.from(body), (error) => {
-              if (error) {
-                reject(new Error(error));
-              } else {
-                console.log('Firmware Updated');
-                resolve();
-              }
-            });
-          });
-        } else {
-          reject(new Error('Error downloading firmware for board.'));
-        }
-      });
-  });
 }
 
 function getVersion() {

--- a/src/preload.js
+++ b/src/preload.js
@@ -11,7 +11,6 @@
 const SerialPort = require('serialport');
 const packageJson = require('../package.json');
 const {mayInjectNativeApi} = require('./originAllowlist');
-const md5 = require('blueimp-md5');
 
 function init() {
   if (!mayInjectNativeApi(document.location.origin)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -457,22 +457,22 @@ async@0.2.x, async@~0.2.9:
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
   integrity sha1-trvgsGdLnXGXCMo43owjfLUmw9E=
 
-async@^0.9.0, async@~0.9.0:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
-  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
-
 async@^1.4.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.0.0, async@^2.1.2, async@^2.1.5:
+async@^2.0.0, async@^2.1.5:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
   dependencies:
     lodash "^4.17.14"
+
+async@~0.9.0:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -482,24 +482,6 @@ author-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
   integrity sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=
-
-avrgirl-arduino@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/avrgirl-arduino/-/avrgirl-arduino-4.2.1.tgz#047c9f2e6ba524559d354e4434a3e2eab4302c99"
-  integrity sha512-9KY2amfHxi182QGc/8D6b+czka0QNqz7Hiywaky88zjF9jhIw7ySmp+INEw0EIe8e6T3VYiC19jKeqdm4jDp6A==
-  dependencies:
-    async "^2.1.2"
-    awty "^0.1.0"
-    browser-serialport "https://github.com/noopkat/browser-serialport#c8628c41c11890d3058875994c15f83f2df8185b"
-    chip.avr.avr109 "^1.1.0"
-    colors "^1.1.2"
-    graceful-fs "^4.1.2"
-    intel-hex "^0.1.2"
-    jscs-loader "^0.3.0"
-    minimist "^1.2.0"
-    serialport "^8.0.5"
-    stk500 "^2.0.2"
-    stk500-v2 "^1.0.4"
 
 aws-sdk@2.28.0:
   version "2.28.0"
@@ -571,13 +553,6 @@ aws4@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
-
-awty@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/awty/-/awty-0.1.0.tgz#8b705c1ee3139f8d6e9f29409d90b74f93e840ba"
-  integrity sha1-i3BcHuMTn41unylAnZC3T5PoQLo=
-  dependencies:
-    isval "0.0.2"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -734,11 +709,6 @@ before-after-hook@^1.1.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
   integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
 
-big.js@^3.1.3:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
-  integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
-
 binary@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
@@ -836,10 +806,6 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
-
-"browser-serialport@https://github.com/noopkat/browser-serialport#c8628c41c11890d3058875994c15f83f2df8185b":
-  version "2.0.3"
-  resolved "https://github.com/noopkat/browser-serialport#c8628c41c11890d3058875994c15f83f2df8185b"
 
 browser-stdout@1.3.0:
   version "1.3.0"
@@ -1060,13 +1026,6 @@ chardet@^0.4.0:
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
-
-chip.avr.avr109@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/chip.avr.avr109/-/chip.avr.avr109-1.1.1.tgz#68b04b125d61d18bd5c0451db894310b46acd609"
-  integrity sha512-+0+cvkHDsy/gizui/zFirTtDpvTQumJSs2SE9lT2BAzyE+CslXWQN9blfjMjhChcyNdZT8mFUQjETVne1gxBBQ==
-  dependencies:
-    intel-hex "*"
 
 chownr@^1.0.1:
   version "1.0.1"
@@ -2102,11 +2061,6 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
-
-emojis-list@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
-  integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.0"
@@ -3312,16 +3266,6 @@ int64-buffer@^0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.9.tgz#9e039da043b24f78b196b283e04653ef5e990f61"
 
-intel-hex@*:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/intel-hex/-/intel-hex-0.1.1.tgz#825445dbabdab8d7988c6dfdb470dfbbb19fd494"
-  integrity sha1-glRF26vauNeYjG39tHDfu7Gf1JQ=
-
-intel-hex@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/intel-hex/-/intel-hex-0.1.2.tgz#c257385207cac680faf0d21181ed0ed8fc6ebb92"
-  integrity sha512-BHdANJX9xz74E1IeaRklWDnUEgVuWKD6HQ6ESklElF+4O9/8UtLzuEYoFOiSWcYZV7I40Xwv6c/BKhJqu0w6lQ==
-
 invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
@@ -3568,11 +3512,6 @@ isstream@0.1.x, isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-isval@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/isval/-/isval-0.0.2.tgz#1ceb0171c89113e3f5098a4f7336caaf33bef03f"
-  integrity sha1-HOsBcciRE+P1CYpPczbKrzO+8D8=
-
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
@@ -3618,15 +3557,6 @@ jscs-jsdoc@^2.0.0:
   dependencies:
     comment-parser "^0.3.1"
     jsdoctypeparser "~1.2.0"
-
-jscs-loader@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/jscs-loader/-/jscs-loader-0.3.0.tgz#3643b0dfcb077eb63d37fed35bf026f3acefd481"
-  integrity sha1-NkOw38sHfrY9N/7TW/Am86zv1IE=
-  dependencies:
-    loader-utils "^0.2.5"
-    rcfinder "^0.1.8"
-    strip-json-comments "^2.0.0"
 
 jscs-preset-wikimedia@~1.0.0:
   version "1.0.1"
@@ -3705,7 +3635,7 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json5@^0.5.0, json5@^0.5.1:
+json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
@@ -3819,16 +3749,6 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
-loader-utils@^0.2.5:
-  version "0.2.17"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
-  integrity sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=
-  dependencies:
-    big.js "^3.1.3"
-    emojis-list "^2.0.0"
-    json5 "^0.5.0"
-    object-assign "^4.0.1"
-
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -3853,11 +3773,6 @@ lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
   integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
-
-lodash.clonedeep@^4.3.2:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
 lodash.cond@^4.3.0:
   version "4.5.2"
@@ -5049,13 +4964,6 @@ rcedit@^1.0.0:
   resolved "https://registry.yarnpkg.com/rcedit/-/rcedit-1.1.2.tgz#7a28edf981953f75b5f3e5d4cbc1f9ffa0abbc78"
   integrity sha512-z2ypB4gbINhI6wVe0JJMmdpmOpmNc4g90sE6/6JSuch5kYnjfz9CxvVPqqhShgR6GIkmtW3W2UlfiXhWljA0Fw==
 
-rcfinder@^0.1.8:
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/rcfinder/-/rcfinder-0.1.9.tgz#f3e80f387ddf9ae80ae30a4100329642eae81115"
-  integrity sha1-8+gPOH3fmugK4wpBADKWQuroERU=
-  dependencies:
-    lodash.clonedeep "^4.3.2"
-
 read-config-file@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-1.2.0.tgz#1fd7dc8ccdad838cac9f686182625290fc94f456"
@@ -5505,7 +5413,7 @@ semver@~2.2.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-2.2.1.tgz#7941182b3ffcc580bff1c17942acdf7951c0d213"
   integrity sha1-eUEYKz/8xYC/8cF5QqzfeVHA0hM=
 
-serialport@^8.0.5, serialport@^8.0.7:
+serialport@^8.0.7:
   version "8.0.7"
   resolved "https://registry.yarnpkg.com/serialport/-/serialport-8.0.7.tgz#9f28b1b7c47333a0962f5505a1c3feb1d90f89a9"
   integrity sha512-R9bfNebs2dblYf5sD/Aaa7j8+siP4X7TGT02lqHM9DF5fyjlrPGXmsLw9+LKOz1AvjGjkxf2NzBVnDpqRX7clQ==
@@ -5693,20 +5601,6 @@ stat-mode@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-0.2.2.tgz#e6c80b623123d7d80cf132ce538f346289072502"
 
-stk500-v2@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/stk500-v2/-/stk500-v2-1.0.4.tgz#f54e406da2221436575f193deea7f12f2c66af0c"
-  integrity sha512-5j7aYxA4S1YbwxQrEoefqtHoPCFCbv267aYdE7WDw4YAO9H4SpL4gg8YfuKoi+jGq+0wBP52D72FJNDTeVxB7Q==
-  dependencies:
-    async "^0.9.0"
-
-stk500@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/stk500/-/stk500-2.0.2.tgz#0e8020410fa4937ece1a2f3eaea908e08ac7efea"
-  integrity sha512-7tkhBdcyQimPyXGtsAqxy56a/3FsryxXcX6p+/M6n8A0mEJF9fgNiNbUprX6A8pe21qGdhzIM+okTORIFKoS9A==
-  dependencies:
-    async "^0.9.0"
-
 stream-buffers@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
@@ -5837,15 +5731,15 @@ strip-indent@^1.0.0, strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 strip-json-comments@~1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
   integrity sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 sudo-prompt@^8.0.0:
   version "8.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -770,11 +770,6 @@ bluebird@^3.5.0, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
-blueimp-md5@^2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.11.0.tgz#eff55d30fe3daddd7e801072e2c4483e5fcfc87c"
-  integrity sha512-xvA4mdnIevstCvNKTRLMOKi7L76U/X/CTs9Yz+PLWmWAC/7SuYi5Xv2J7bAhJnE2+LcLv+x4+0vusvKgM9LnZQ==
-
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"


### PR DESCRIPTION
Context: We need to update electron-packager in order to get our continuous integration tests running, but we need to update to a 10.x.x version of Node to do so. This causes an error due to a library that avrgirl uses. Since we aren't currently using the avrgirl code, and it's not on our short term plan, I pulled out the code in the code-dot-org repository and here so we can unblock the other updates we need here.

Documentation on what was removed: https://docs.google.com/document/d/1jJYT-dZyPHdCSj1dl03EMCFq2qcduFS9FHJ-kfkSZT8/edit

PR of this change on the code-dot-org side: https://github.com/code-dot-org/code-dot-org/pull/38542

PR where we added this: https://github.com/code-dot-org/browser/pull/52/files