### PR TITLE
Download Version Notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This is the process of setting up certificates (paired with private keys) on you
 ### Releasing a new version
 
 1. Bump the version in `package.json`
+   1. If you want users to see a notification suggesting they update to this version, bump the `const suggestedVersion` in `main.json` to reflect the version in `package.json`.
 2. Run `yarn release`
 
 ### Generating a new Developer ID Application

--- a/src/browser.js
+++ b/src/browser.js
@@ -8,8 +8,7 @@
 // First step: Always be production, unless told otherwise.
 if (process.env.NODE_ENV === undefined) process.env.NODE_ENV = 'production';
 
-const {ipcRenderer, shell} = require('electron');
-const electron = require('electron');
+const {ipcRenderer} = require('electron');
 const {
   NAVIGATION_REQUESTED,
   RELOAD_REQUESTED,
@@ -170,13 +169,3 @@ function handleLoadAbort(event) {
 function handleLoadRedirect(event) {
   resetExitedState();
 }
-
-const notificationText = {
-  title: 'New Version of the Code.org Maker App Available',
-  body: 'Click this notification to download the latest version of the Code.org Maker App',
-};
-let notification = new electron.remote.Notification(notificationText);
-notification.on('click', (event, arg) => {
-  shell.openExternal('https://studio.code.org/maker/setup');
-});
-notification.show();

--- a/src/browser.js
+++ b/src/browser.js
@@ -8,7 +8,8 @@
 // First step: Always be production, unless told otherwise.
 if (process.env.NODE_ENV === undefined) process.env.NODE_ENV = 'production';
 
-const {ipcRenderer} = require('electron');
+const {ipcRenderer, shell} = require('electron');
+const electron = require('electron');
 const {
   NAVIGATION_REQUESTED,
   RELOAD_REQUESTED,
@@ -169,3 +170,13 @@ function handleLoadAbort(event) {
 function handleLoadRedirect(event) {
   resetExitedState();
 }
+
+const notificationText = {
+  title: 'New Version of the Code.org Maker App Available',
+  body: 'Click this notification to download the latest version of the Code.org Maker App',
+};
+let notification = new electron.remote.Notification(notificationText);
+notification.on('click', (event, arg) => {
+  shell.openExternal('https://studio.code.org/maker/setup');
+});
+notification.show();

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const {app, BrowserWindow} = require('electron');
+const {app, BrowserWindow, shell} = require('electron');
 const path = require('path');
 const url = require('url');
 const setupMenus = require('./menus');
@@ -8,6 +8,7 @@ const {autoUpdater} = require('electron-updater');
 const log = require('electron-log');
 const checkForManualUpdate = require('./checkForManualUpdate');
 const firehoseClient = require('./firehose');
+const electron = require('electron');
 
 autoUpdater.logger = log;
 autoUpdater.logger.transports.file.level = 'info';
@@ -19,6 +20,8 @@ app.setName('Code.org Maker App');
 
 let mainWindow = null;
 let manualUpdateRequired = false;
+
+const suggestedVersion = '1.1.9';
 
 function createMainWindow() {
   mainWindow = new BrowserWindow({
@@ -71,6 +74,23 @@ function createAutoUpdateDebugWindow() {
   statusWindow.loadURL(`file://${__dirname}/version.html#v${app.getVersion()}`);
   return statusWindow;
 }
+
+// If current version is lower than our suggested version, show notification to update
+function createSuggestedUpdateNotification() {
+  // Versions are expected as strings in the format x.y.z
+  if (app.getVersion() < suggestedVersion) {
+    const notificationText = {
+      title: 'New Version of the Code.org Maker App Available',
+      body: 'Click this notification to download the latest version of the Code.org Maker App',
+    };
+    let notification = new electron.Notification(notificationText);
+    notification.on('click', (event, arg) => {
+      shell.openExternal('https://studio.code.org/maker/setup');
+    });
+    notification.show();
+  }
+}
+
 autoUpdater.on('checking-for-update', () => {
   sendStatusToWindow('Checking for update...');
 });
@@ -100,6 +120,7 @@ autoUpdater.on('update-downloaded', (info) => {
 app.on('ready', function() {
   createMainWindow();
   createAutoUpdateDebugWindow();
+  createSuggestedUpdateNotification();
   if (!manualUpdateRequired) {
     setTimeout(function() {
       autoUpdater.checkForUpdatesAndNotify();


### PR DESCRIPTION
Video of process: 
![notification](https://user-images.githubusercontent.com/2959170/105777725-bc237f80-5f1f-11eb-8df4-c682441b8114.gif)

We want to find an unobtrusive way to encourage folks to update their Maker App. The notification opens the maker setup page, which includes instructions to download the most recent version.

These changes also include instructions in the releasing instructions on how to add this notification for future releases. At the moment, everyone at 1.1.8 (current version) and below will see this.