### PR TITLE
Revert "Download Version Notification"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ This is the process of setting up certificates (paired with private keys) on you
 ### Releasing a new version
 
 1. Bump the version in `package.json`
-   1. If you want users to see a notification suggesting they update to this version, bump the `const suggestedVersion` in `main.json` to reflect the version in `package.json`.
 2. Run `yarn release`
 
 ### Generating a new Developer ID Application

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const {app, BrowserWindow, shell} = require('electron');
+const {app, BrowserWindow} = require('electron');
 const path = require('path');
 const url = require('url');
 const setupMenus = require('./menus');
@@ -8,7 +8,6 @@ const {autoUpdater} = require('electron-updater');
 const log = require('electron-log');
 const checkForManualUpdate = require('./checkForManualUpdate');
 const firehoseClient = require('./firehose');
-const electron = require('electron');
 const contextMenu = require('electron-context-menu');
 
 autoUpdater.logger = log;
@@ -21,8 +20,6 @@ app.setName('Code.org Maker App');
 
 let mainWindow = null;
 let manualUpdateRequired = false;
-
-const suggestedVersion = '1.1.9';
 
 function createMainWindow() {
   mainWindow = new BrowserWindow({
@@ -75,23 +72,6 @@ function createAutoUpdateDebugWindow() {
   statusWindow.loadURL(`file://${__dirname}/version.html#v${app.getVersion()}`);
   return statusWindow;
 }
-
-// If current version is lower than our suggested version, show notification to update
-function createSuggestedUpdateNotification() {
-  // Versions are expected as strings in the format x.y.z
-  if (app.getVersion() < suggestedVersion) {
-    const notificationText = {
-      title: 'New Version of the Code.org Maker App Available',
-      body: 'Click this notification to download the latest version of the Code.org Maker App',
-    };
-    let notification = new electron.Notification(notificationText);
-    notification.on('click', (event, arg) => {
-      shell.openExternal('https://studio.code.org/maker/setup');
-    });
-    notification.show();
-  }
-}
-
 autoUpdater.on('checking-for-update', () => {
   sendStatusToWindow('Checking for update...');
 });
@@ -121,7 +101,6 @@ autoUpdater.on('update-downloaded', (info) => {
 app.on('ready', function() {
   createMainWindow();
   createAutoUpdateDebugWindow();
-  createSuggestedUpdateNotification();
   if (!manualUpdateRequired) {
     setTimeout(function() {
       autoUpdater.checkForUpdatesAndNotify();


### PR DESCRIPTION
Reverts code-dot-org/browser#86

Sometimes I get confused with how the Maker App gets updated and this was one of those situations. I realized that in order to update the suggested version, we'd need to deploy the app again, so it wouldn't tell current users to update. This should be re-implemented so that it checks somewhere online (GitHub? S3?) to see if there is a new message and then to display it. This would allow us to recommend updates or warn of potential future deprecation. But I know we are releasing the Maker App this week, so we'll need to do the work to reimplement this another time.

cc: @aaronwaggener - just a heads up we'll want this merged before deploying the Maker App.