### PR TITLE
Change GitHub Actions to only run once on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: Build
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 env: 
   ELECTRON_CACHE: $HOME/.cache/electron
 


### PR DESCRIPTION
While working on adding Actions to another repo, I learned a more efficient way to have this workflow run on pull requests and `main`. 

This change causes our workflow to run for `pull_request`s (which will include any incremental pushes to the branch after a PR has been opened) and then once on `main` when we merge. Without this change we were seeing checks run twice on PRs because both the `pull_request` and `push` events were getting triggered  (see below)

**Before**
![image](https://user-images.githubusercontent.com/73763104/133293300-ab936886-1fb5-4f9d-921a-1a33cb2e1005.png)

**After**
![image](https://user-images.githubusercontent.com/73763104/133294358-452433c6-f250-41b5-b64a-741347473472.png)

