### PR TITLE
Revert "Bump electron from 10.4.6 to 11.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@octokit/rest": "^18.6.0",
     "chai": "^4.1.2",
-    "electron": "^11.5.0",
+    "electron": "^10.4.3",
     "electron-builder": "^22.10.5",
     "electron-forge": "5.2.3",
     "electron-notarize": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2381,10 +2381,10 @@ electron-wix-msi@^2.1.1:
     lodash "^4.17.15"
     uuid "^3.3.3"
 
-electron@^11.5.0:
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.5.0.tgz#f1650543b9d8f2047d3807755bdb120153ed210f"
-  integrity sha512-WjNDd6lGpxyiNjE3LhnFCAk/D9GIj1rU3GSDealVShhkkkPR3Vh4q8ErXGDl1OAO/faomVa10KoFPUN/pLbNxg==
+electron@^10.4.3:
+  version "10.4.6"
+  resolved "https://registry.npmjs.org/electron/-/electron-10.4.6.tgz"
+  integrity sha512-HCKJrWy9ZF4x7dOE8Q3+lXFVz/We7D+4mAZJHtwdeZT3EjcGrm575TsuuzY8AOUASohmezaBANcSmJy0zVlAzw==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
Reverts code-dot-org/browser#102

Broke build.