### PR TITLE
Remove lodash as a top-level dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "electron-is-dev": "^0.3.0",
     "electron-log": "^1.3.0",
     "electron-updater": "^4.0.0",
-    "lodash": "^4.17.21",
     "serialport": "^9.0.7"
   },
   "devDependencies": {

--- a/test/originAllowlistTest.js
+++ b/test/originAllowlistTest.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const { expect } = require('chai');
 const {URL} = require('url');
 const {
@@ -74,7 +73,7 @@ function originFromUrl(url) {
 
 describe('mayInjectNativeApi', () => {
   // These should get the native APIs injected into the page
-  _.uniq(
+  new Set(
     [
       ...ALLOWLISTED_INTERNAL_PAGES,
     ].map(originFromUrl)
@@ -85,7 +84,7 @@ describe('mayInjectNativeApi', () => {
   });
 
   // These should never get native APIs injected into the page
-  _.uniq(
+  new Set(
     [
       ...ALLOWLISTED_EXTERNAL_PAGES,
       ...BLOCKLISTED_PAGES,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2460,7 +2460,7 @@ lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
 
-lodash@^4.17.10, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Refactored the one place we were using `lodash`.