### PR TITLE
[Maker Cleanup] Update browser README with deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Code.org Maker App [![GitHub release](https://img.shields.io/github/release/code-dot-org/browser.svg)](https://github.com/code-dot-org/browser/releases/latest) [![Build Status](https://github.com/code-dot-org/browser/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/code-dot-org/browser/actions/workflows/ci.yml)
+# Code.org Maker App - DEPRECATED
 
-Simple browser exposing native node-serialport to web-based tools on allowlisted Code.org domains.
+[![Maintenance](https://img.shields.io/badge/Maintained%3F-no-red.svg)](https://bitbucket.org/lbesson/ansi-colors)
+
+Simple browser exposing native node-serialport to web-based tools on allowlisted Code.org domains.  
+
+This repo is deprecated because the Code.org Maker App is no longer supported. Boards now connect directly through the browser, so no app is needed to access the Maker Toolkit. Read more [here](https://support.code.org/hc/en-us/articles/11304760762125-Deprecating-the-Maker-App-and-Chrome-Serial-Extension).
 
 ## Installation
 


### PR DESCRIPTION
This PR updates `README.md` to include the 'no maintenance' badge and 'DEPRECATION' in header. This repo is  being deprecated because the Code.org Maker App is no longer supported.

# Links
[jira ticket](https://codedotorg.atlassian.net/browse/SL-1000)
[Slack thread which includes deprecation steps](https://codedotorg.slack.com/archives/C0T0PNTM3/p1689883997612429)

# Follow-up
- Deprecate package in npm
- Set repo to read-only (archive)